### PR TITLE
Allow access to the Program for a Probe

### DIFF
--- a/manager/probe.go
+++ b/manager/probe.go
@@ -199,6 +199,10 @@ func (p *Probe) Init(manager *Manager) error {
 	return p.init()
 }
 
+func (p *Probe) Program() *ebpf.Program {
+	return p.program
+}
+
 // init - Internal initialization function
 func (p *Probe) init() error {
 	// Load spec if necessary


### PR DESCRIPTION
This is preferable to `manager.GetProgram(id ProbeIdentificationPair)` when you already have a reference to the `Probe`.