### PR TITLE
Fix nil pointer dereference when a LostHandler is not set

### DIFF
--- a/manager/perf.go
+++ b/manager/perf.go
@@ -116,7 +116,9 @@ func (m *PerfMap) Start() error {
 				continue
 			}
 			if record.LostSamples > 0 {
-				m.LostHandler(record.CPU, record.LostSamples, m, m.manager)
+				if m.LostHandler != nil {
+					m.LostHandler(record.CPU, record.LostSamples, m, m.manager)
+				}
 				continue
 			}
 			m.DataHandler(record.CPU, record.RawSample, m, m.manager)


### PR DESCRIPTION
What does this PR do ?
-----------------------

If a `PerfMap` is initialized without a `LostHandler`, a nil pointer dereference can happen when a record is lost by the kernel.
Make sure `LostHandler` isn't nil before call it.