### PR TITLE
Remove path from the uprobe event names

### DIFF
--- a/manager/probe.go
+++ b/manager/probe.go
@@ -516,7 +516,7 @@ func (p *Probe) detachUprobe() error {
 	}
 
 	// Write uprobe_events line to remove hook point
-	return DisableUprobeEvent(probeType, funcName, p.BinaryPath, p.UID, p.attachPID)
+	return DisableUprobeEvent(probeType, funcName, p.UID, p.attachPID)
 }
 
 // attachCGroup - Attaches the probe to a cgroup hook point

--- a/manager/utils.go
+++ b/manager/utils.go
@@ -22,6 +22,9 @@ const (
 	initialized
 	paused
 	running
+
+	// MaxEventNameLen - maximum length for a kprobe (or uprobe) event name
+	MaxEventNameLen = 64
 )
 
 // ConcatErrors - Concatenate 2 errors into one error.
@@ -165,6 +168,10 @@ func EnableKprobeEvent(probeType, funcName, UID, maxactiveStr string, kprobeAtta
 	// Generate event name
 	eventName := SanitizeEventName(fmt.Sprintf("%s_%s_%s_%d", probeType, funcName, UID, kprobeAttachPID))
 
+	if len(eventName) > MaxEventNameLen {
+		return -1, errors.Errorf("event name too long (kernel limit is %d): %s", MaxEventNameLen, eventName)
+	}
+
 	// Write line to kprobe_events
 	kprobeEventsFileName := "/sys/kernel/debug/tracing/kprobe_events"
 	f, err := os.OpenFile(kprobeEventsFileName, os.O_APPEND|os.O_WRONLY, 0666)
@@ -198,6 +205,10 @@ func DisableKprobeEvent(probeType, funcName, UID string, kprobeAttachPID int) er
 	// Generate event name
 	eventName := SanitizeEventName(fmt.Sprintf("%s_%s_%s_%d", probeType, funcName, UID, kprobeAttachPID))
 
+	if len(eventName) > MaxEventNameLen {
+		return errors.Errorf("event name too long (kernel limit is %d): %s", MaxEventNameLen, eventName)
+	}
+
 	// Write line to kprobe_events
 	kprobeEventsFileName := "/sys/kernel/debug/tracing/kprobe_events"
 	f, err := os.OpenFile(kprobeEventsFileName, os.O_APPEND|os.O_WRONLY, 0)
@@ -226,6 +237,10 @@ func DisableKprobeEvent(probeType, funcName, UID string, kprobeAttachPID int) er
 func EnableUprobeEvent(probeType, funcName, path, UID string, uprobeAttachPID int) (int, error) {
 	// Generate event name
 	eventName := SanitizeEventName(fmt.Sprintf("%s_%s_%s_%d", probeType, funcName, UID, uprobeAttachPID))
+
+	if len(eventName) > MaxEventNameLen {
+		return -1, errors.Errorf("event name too long (kernel limit is %d): %s", MaxEventNameLen, eventName)
+	}
 
 	// Retrieve dynamic symbol offset
 	offset, err := findSymbolOffset(path, funcName)
@@ -291,6 +306,10 @@ func findSymbolOffset(path string, name string) (uint64, error) {
 func DisableUprobeEvent(probeType, funcName, UID string, uprobeAttachPID int) error {
 	// Generate event name
 	eventName := SanitizeEventName(fmt.Sprintf("%s_%s_%s_%d", probeType, funcName, UID, uprobeAttachPID))
+
+	if len(eventName) > MaxEventNameLen {
+		return errors.Errorf("event name too long (kernel limit is %d): %s", MaxEventNameLen, eventName)
+	}
 
 	// Write uprobe_events line
 	uprobeEventsFileName := "/sys/kernel/debug/tracing/uprobe_events"

--- a/manager/utils.go
+++ b/manager/utils.go
@@ -225,7 +225,7 @@ func DisableKprobeEvent(probeType, funcName, UID string, kprobeAttachPID int) er
 // to remove the krpobe.
 func EnableUprobeEvent(probeType, funcName, path, UID string, uprobeAttachPID int) (int, error) {
 	// Generate event name
-	eventName := SanitizeEventName(fmt.Sprintf("%s_%s_%s_%s_%d", probeType, funcName, path, UID, uprobeAttachPID))
+	eventName := SanitizeEventName(fmt.Sprintf("%s_%s_%s_%d", probeType, funcName, UID, uprobeAttachPID))
 
 	// Retrieve dynamic symbol offset
 	offset, err := findSymbolOffset(path, funcName)
@@ -288,9 +288,9 @@ func findSymbolOffset(path string, name string) (uint64, error) {
 }
 
 // DisableUprobeEvent - Removes a uprobe from uprobe_events
-func DisableUprobeEvent(probeType, funcName, path, UID string, uprobeAttachPID int) error {
+func DisableUprobeEvent(probeType, funcName, UID string, uprobeAttachPID int) error {
 	// Generate event name
-	eventName := SanitizeEventName(fmt.Sprintf("%s_%s_%s_%s_%d", probeType, funcName, path, UID, uprobeAttachPID))
+	eventName := SanitizeEventName(fmt.Sprintf("%s_%s_%s_%d", probeType, funcName, UID, uprobeAttachPID))
 
 	// Write uprobe_events line
 	uprobeEventsFileName := "/sys/kernel/debug/tracing/uprobe_events"


### PR DESCRIPTION
What does this PR do ?
-----------------------

This PR removes the binary path from the uprobe event name written in `uprobe_events`. When the binary path is too long, the event name will eventually exceed [the kernel limit](https://elixir.bootlin.com/linux/latest/source/kernel/trace/trace.h#L1974).