### PR TITLE
Add RenameProbeIdentificationPair sanity check

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -429,6 +429,12 @@ func (m *Manager) GetProbe(id ProbeIdentificationPair) (*Probe, bool) {
 // RenameProbeIdentificationPair - Renames a probe identification pair. This change will propagate to all the features in
 // the manager that will try to select the probe by its old ProbeIdentificationPair.
 func (m *Manager) RenameProbeIdentificationPair(oldID ProbeIdentificationPair, newID ProbeIdentificationPair) error {
+	// sanity check: make sure the newID doesn't already exists
+	for _, mProbe := range m.Probes {
+		if mProbe.IdentificationPairMatches(newID) {
+			return ErrIdentificationPairInUse
+		}
+	}
 	p, ok := m.GetProbe(oldID)
 	if !ok {
 		return ErrSymbolNotFound
@@ -1366,14 +1372,14 @@ func (m *Manager) sanityCheck() error {
 		cache[perfMap.Name] = true
 	}
 
-	// Check if probes section are unique, request the usage of CloneProbe otherwise
+	// Check if probes identification pairs are unique, request the usage of CloneProbe otherwise
 	cache = map[string]bool{}
 	for _, managerProbe := range m.Probes {
-		_, ok := cache[managerProbe.Section]
+		_, ok := cache[managerProbe.GetIdentificationPair().String()]
 		if ok {
 			return errors.Wrapf(ErrCloneProbeRequired, "%v failed the sanity check", managerProbe.GetIdentificationPair())
 		}
-		cache[managerProbe.Section] = true
+		cache[managerProbe.GetIdentificationPair().String()] = true
 	}
 	return nil
 }


### PR DESCRIPTION
What does this PR do ?
-----------------------

The manager is supposed to hold a list of probes that have unique `ProbeIdentificationPair` (which means unique (UID, section) tuples). Right now, it is possible to use the `RenameProbeIdentificationPair` method to rename a `Probe` to an existing (UID, section) tuple.

The reason why this is a problem is because the activation validator (and all the selection features of the `Manager`) gets confused and will yield incorrect results (it is indeed unable to differentiate the 2 probes, and therefore will choose the first one, that might, or not, be properly activated).