### PR TITLE
Add DefaultKProbeMaxActive parameter

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -243,6 +243,10 @@ type Options struct {
 	// See PerfMap.Watermark for more.
 	DefaultWatermark int
 
+	// DefaultKProbeMaxActive - Manager-level default value for the kprobe max active parameter.
+	// See Probe.MaxActive for more.
+	DefaultKProbeMaxActive int
+
 	// RLimit - The maps & programs provided to the manager might exceed the maximum allowed memory lock.
 	// (RLIMIT_MEMLOCK) If a limit is provided here it will be applied when the manager is initialized.
 	RLimit *unix.Rlimit

--- a/manager/probe.go
+++ b/manager/probe.go
@@ -302,6 +302,11 @@ func (p *Probe) init() error {
 		p.Ifindex = int32(inter.Index)
 	}
 
+	// Default max active value
+	if p.KProbeMaxActive == 0 {
+		p.KProbeMaxActive = p.manager.options.DefaultKProbeMaxActive
+	}
+
 	// update probe state
 	p.state = initialized
 	return nil


### PR DESCRIPTION
What does this PR do ?
-----------------------

This PR adds a default `KProbeMaxActive` parameter so that we can define this value at the manager level instead of having to pass a value to each probe.