### PR TITLE
Add KProbe attach / detach retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/ebpf
 go 1.12
 
 require (
+	github.com/avast/retry-go v2.7.0+incompatible
 	github.com/florianl/go-tc v0.2.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/avast/retry-go v2.7.0+incompatible h1:XaGnzl7gESAideSjr+I8Hki/JBi+Yb9baHlMRPeSC84=
+github.com/avast/retry-go v2.7.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/florianl/go-tc v0.2.0 h1:k3Dr3rtmMP2KCRlWgRUC6XKBZA5lL9rNBAr80H50/6k=

--- a/manager/examples/programs/kprobe/main.go
+++ b/manager/examples/programs/kprobe/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
+	"github.com/DataDog/ebpf/manager"
 	"github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
-
-	"github.com/DataDog/ebpf/manager"
+	"time"
 )
 
 var m = &manager.Manager{
@@ -33,8 +33,13 @@ var m = &manager.Manager{
 }
 
 func main() {
+	options := manager.Options{
+		DefaultProbeRetry: 2,
+		DefaultProbeRetryDelay: time.Second,
+	}
+
 	// Initialize the manager
-	if err := m.Init(recoverAssets()); err != nil {
+	if err := m.InitWithOptions(recoverAssets(), options); err != nil {
 		logrus.Fatal(err)
 	}
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/florianl/go-tc"
 	"github.com/hashicorp/go-multierror"
@@ -295,6 +296,12 @@ type Options struct {
 	// DefaultKProbeMaxActive - Manager-level default value for the kprobe max active parameter.
 	// See Probe.MaxActive for more.
 	DefaultKProbeMaxActive int
+
+	// ProbeRetry - Defines the number of times that a probe will retry to attach / detach on error.
+	DefaultProbeRetry uint
+
+	// ProbeRetryDelay - Defines the delay to wait before a probe should retry to attach / detach on error.
+	DefaultProbeRetryDelay time.Duration
 
 	// RLimit - The maps & programs provided to the manager might exceed the maximum allowed memory lock.
 	// (RLIMIT_MEMLOCK) If a limit is provided here it will be applied when the manager is initialized.

--- a/manager/probe.go
+++ b/manager/probe.go
@@ -316,7 +316,12 @@ func (p *Probe) init() error {
 
 	// Default retry
 	if p.ProbeRetry == 0 {
-		p.ProbeRetry = p.manager.options.DefaultProbeRetry
+		if p.manager.options.DefaultProbeRetry > 0 {
+			p.ProbeRetry = p.manager.options.DefaultProbeRetry
+		} else {
+			// default to 1 to allow at least one attach / detach attempt
+			p.ProbeRetry = 1
+		}
 	}
 
 	// Default retry delay


### PR DESCRIPTION
What does this PR do ?
-----------------------

This PR implements a retry on a `probe` attach and detach attempt. The retry can be configured at the `manager` level and will be applied to all probes, or at the probe level.