### PR TITLE
Add attach and detach error filter

### DIFF
--- a/manager/probe.go
+++ b/manager/probe.go
@@ -348,7 +348,7 @@ func (p *Probe) Attach() error {
 		if errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.EINVAL) {
 			return nil
 		}
-		return nil
+		return err
 	}, retry.Attempts(p.ProbeRetry), retry.Delay(p.ProbeRetryDelay))
 }
 


### PR DESCRIPTION
What does this PR do ?
-----------------------

This PR filters out a few errors from the probe retry to avoid retrying to attach a probe that failed with a non temporary error.