### PR TITLE
Cleanup internal fields

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -965,12 +965,12 @@ func (m *Manager) CloneProgram(UID string, newProbe Probe, constantsEditors []Co
 
 	// Write current maps
 	if err = m.rewriteMaps(newProbe.programSpec, m.collection.Maps); err != nil {
-		return errors.Wrapf(err, "coulnd't rewrite maps in %v", newProbe.GetIdentificationPair())
+		return errors.Wrapf(err, "couldn't rewrite maps in %v", newProbe.GetIdentificationPair())
 	}
 
 	// Rewrite with new maps
 	if err = m.rewriteMaps(newProbe.programSpec, mapEditors); err != nil {
-		return errors.Wrapf(err, "coulnd't rewrite maps in %v", newProbe.GetIdentificationPair())
+		return errors.Wrapf(err, "couldn't rewrite maps in %v", newProbe.GetIdentificationPair())
 	}
 
 	// Init

--- a/manager/map.go
+++ b/manager/map.go
@@ -137,7 +137,6 @@ func (m *Map) Close(cleanup MapCleanupType) error {
 	if m.state < initialized {
 		return ErrMapInitialized
 	}
-	m.state = reset
 	return m.close(cleanup)
 }
 
@@ -178,7 +177,21 @@ func (m *Map) close(cleanup MapCleanupType) error {
 		if m.PinPath != "" {
 			err = ConcatErrors(err, os.Remove(m.PinPath))
 		}
-		return ConcatErrors(err, m.array.Close())
+		err = ConcatErrors(err, m.array.Close())
+		if err != nil {
+			return err
+		}
+		m.reset()
 	}
 	return nil
+}
+
+// reset - Cleans up the internal fields of the map
+func (m *Map) reset() {
+	m.array = nil
+	m.arraySpec = nil
+	m.manager = nil
+	m.state = reset
+	m.externalMap = false
+	m.editedMap = false
 }

--- a/manager/utils.go
+++ b/manager/utils.go
@@ -226,7 +226,7 @@ func DisableKprobeEvent(probeType, funcName, UID string, kprobeAttachPID int) er
 			// probe already has been cleared by the first.
 			return nil
 		} else {
-			return errors.Wrapf(err, "cannot write %q to kprobe_events: %v", cmd)
+			return errors.Wrapf(err, "cannot write %q to kprobe_events", cmd)
 		}
 	}
 	return nil
@@ -320,7 +320,7 @@ func DisableUprobeEvent(probeType, funcName, UID string, uprobeAttachPID int) er
 	defer f.Close()
 	cmd := fmt.Sprintf("-:%s\n", eventName)
 	if _, err = f.WriteString(cmd); err != nil {
-		return errors.Wrapf(err, "cannot write %q to uprobe_events: %v", cmd)
+		return errors.Wrapf(err, "cannot write %q to uprobe_events", cmd)
 	}
 	return nil
 }


### PR DESCRIPTION
What does this PR do ?
-----------------------

This PR introduces a proper cleanup method for `Probe` and `Map` that cleans up internal fields after a successful call to `stop` (for `Probe`) and to `close` (for `Map`).

What's the problem ?
---------------------

`Probe` and `Map` are not properly cleaned up on `Stop` or `Close`. When a `Probe` is restarted after being stopped, it will fail as some internal fields are reused unchanged.