### PR TITLE
Fix syscall lookup on arm64

### DIFF
--- a/manager/utils.go
+++ b/manager/utils.go
@@ -119,6 +119,8 @@ func getSyscallFnNameWithKallsyms(name string, kallsymsContent string) (string, 
 	switch runtime.GOARCH {
 	case "386":
 		arch = "ia32"
+	case: "arm64":
+		arch = "arm64"
 	default:
 		arch = "x64"
 	}


### PR DESCRIPTION
I ran the arm docker image `datadog/agent-arm64:7.24.0-rc.5-jmx` and hit a bunch of errors with the system probe

This looks like a known issue https://github.com/DataDog/datadog-agent/issues/6418, but with the latest version, the stack trace is a bit different 

```
goroutine 1 [running]:
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.getSyscallPrefix(0x3631623838, 0x0)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/syscall_helpers.go:44 +0x238
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.getSyscallFnName(...)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/syscall_helpers.go:58
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.expandSyscallSections(0x21d06aa, 0x6, 0x1, 0x0, 0x0, 0x0, 0x0, 0x412844, 0x30)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/syscall_helpers.go:81 +0x28
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.ExpandSyscallProbesSelector(0x21d770b, 0x8, 0x21d06aa, 0x6, 0x1, 0x0, 0x0, 0x0, 0xa0, 0x214bcc0, ...)
	/go/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/syscall_helpers.go:149 +0x64
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.init()
	/go/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/event_types.go:42 +0x454
system-probe exited with code 2, signal 0, restarting in 2 seconds
panic: could not find a valid syscall name

goroutine 1 [running]:
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.getSyscallPrefix(0x3631623838, 0x0)
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/syscall_helpers.go:44 +0x238
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.getSyscallFnName(...)
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/syscall_helpers.go:58
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.expandSyscallSections(0x1dba5a6, 0x6, 0x1, 0x0, 0x0, 0x0, 0x0, 0x410e3c, 0x30)
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/syscall_helpers.go:81 +0x28
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.ExpandSyscallProbesSelector(0x1dbf203, 0x8, 0x1dba5a6, 0x6, 0x1, 0x0, 0x0, 0x0, 0x4000548000, 0x40001426e0, ...)
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/syscall_helpers.go:149 +0x64
github.com/DataDog/datadog-agent/pkg/security/ebpf/probes.init()
	/.omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/ebpf/probes/event_types.go:42 +0x454
security-agent exited with code 2, signal 0, restarting in 2 seconds
```

From an arm64 raspberry pi, I got

```
ubuntu@ubuntu:~$ grep sys_open /proc/kallsyms
[...]
0000000000000000 T __arm64_sys_open
[...]
```

So i'm proposing this patch to fix the error. 

I don't know how to test it though, I haven't setup the toolchain to build the agent on arm