### PR TITLE
Reset probe on stop, even if it is not running

### DIFF
--- a/manager/probe.go
+++ b/manager/probe.go
@@ -470,6 +470,7 @@ func (p *Probe) Stop() error {
 	p.stateLock.Lock()
 	defer p.stateLock.Unlock()
 	if p.state < running || !p.Enabled {
+		p.reset()
 		return nil
 	}
 	return p.stop(true)


### PR DESCRIPTION
What does this PR do ?
-----------------------

Reset a probe when it is closed, even if it is not currently running. This prevents a `Probe` from keeping a reference to an `ebpf.Program` that was closed (thus pointing to a kernel program that was unloaded).