### PR TITLE
Re-use existing kprobe_events entries

### DIFF
--- a/manager/probe.go
+++ b/manager/probe.go
@@ -367,7 +367,9 @@ func (p *Probe) attach() error {
 		return nil
 	}
 	if p.state < initialized {
-		p.lastError = ErrProbeNotInitialized
+		if p.lastError == nil {
+			p.lastError = ErrProbeNotInitialized
+		}
 		return ErrProbeNotInitialized
 	}
 

--- a/manager/utils.go
+++ b/manager/utils.go
@@ -188,7 +188,7 @@ func EnableKprobeEvent(probeType, funcName, UID, maxactiveStr string, kprobeAtta
 	}
 	defer f.Close()
 	cmd := fmt.Sprintf("%s%s:%s %s\n", probeType, maxactiveStr, eventName, funcName)
-	if _, err = f.WriteString(cmd); err != nil {
+	if _, err = f.WriteString(cmd); err != nil && !os.IsExist(err) {
 		return -1, errors.Wrapf(err, "cannot write %q to kprobe_events", cmd)
 	}
 
@@ -266,7 +266,7 @@ func EnableUprobeEvent(probeType, funcName, path, UID string, uprobeAttachPID in
 
 	cmd := fmt.Sprintf("%s:%s %s:%#x\n", probeType, eventName, path, offset)
 
-	if _, err = f.WriteString(cmd); err != nil {
+	if _, err = f.WriteString(cmd); err != nil && !os.IsExist(err) {
 		return -1, errors.Wrapf(err, "cannot write %q to uprobe_events", cmd)
 	}
 


### PR DESCRIPTION
### What does this PR do ?

This PR ensures that a manager re-uses an existing (and matching) entry in `kprobe_events` or `uprobe_events`. Since the name of the kprobes inserted by the manager depends on the PID of the process, this collision can only rarely happen (because it requires the same pid to be re-used). That said, it has happened once in the datadog-agent, which prevented the network tracer and the security module from starting.