### PR TITLE
Fix uprobe on non-PIE binaries

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1010,7 +1010,12 @@ func (m *Manager) matchSpecs() error {
 		if err != nil {
 			return err
 		}
-		probe.programSpec = programSpec
+		if !probe.CopyProgram {
+			probe.programSpec = programSpec
+		} else {
+			probe.programSpec = programSpec.Copy()
+			m.collectionSpec.Programs[probe.Section + probe.UID] = probe.programSpec
+		}
 	}
 
 	// Match maps


### PR DESCRIPTION
What does this PR do ?
-----------------------

- This PR fixes how the library computes symbol offsets for uprobes.
- This PR also introduces `CopyProgram` which can be used to duplicate a program so that multiple unique instances of the program can be loaded (useful if you need the same program with different constants).

Motivation
-----------

The symbol offset used to attach a uprobe needs to be computed from the base LOAD address of the binary. Depending on the ELF executable type, the base LOAD address might not be 0x0 (namely for non-PIE executable), in which case the offset must be adjusted.