### PR TITLE
Switch from golang.org/x/xerrors to stdlib

### DIFF
--- a/abi.go
+++ b/abi.go
@@ -3,14 +3,13 @@ package ebpf
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"syscall"
 
 	"github.com/DataDog/ebpf/internal"
-
-	"golang.org/x/xerrors"
 )
 
 // MapABI are the attributes of a Map which are available across all supported kernels.
@@ -35,7 +34,7 @@ func newMapABIFromSpec(spec *MapSpec) *MapABI {
 func newMapABIFromFd(fd *internal.FD) (string, *MapABI, error) {
 	info, err := bpfGetMapInfoByFD(fd)
 	if err != nil {
-		if xerrors.Is(err, syscall.EINVAL) {
+		if errors.Is(err, syscall.EINVAL) {
 			abi, err := newMapABIFromProc(fd)
 			return "", abi, err
 		}
@@ -98,7 +97,7 @@ func newProgramABIFromSpec(spec *ProgramSpec) *ProgramABI {
 func newProgramABIFromFd(fd *internal.FD) (string, *ProgramABI, error) {
 	info, err := bpfGetProgInfoByFD(fd)
 	if err != nil {
-		if xerrors.Is(err, syscall.EINVAL) {
+		if errors.Is(err, syscall.EINVAL) {
 			return newProgramABIFromProc(fd)
 		}
 
@@ -127,7 +126,7 @@ func newProgramABIFromProc(fd *internal.FD) (string, *ProgramABI, error) {
 		"prog_type": &abi.Type,
 		"prog_tag":  &name,
 	})
-	if xerrors.Is(err, errMissingFields) {
+	if errors.Is(err, errMissingFields) {
 		return "", nil, &internal.UnsupportedFeatureError{
 			Name:           "reading ABI from /proc/self/fdinfo",
 			MinimumVersion: internal.Version{4, 11, 0},
@@ -153,12 +152,12 @@ func scanFdInfo(fd *internal.FD, fields map[string]interface{}) error {
 	defer fh.Close()
 
 	if err := scanFdInfoReader(fh, fields); err != nil {
-		return xerrors.Errorf("%s: %w", fh.Name(), err)
+		return fmt.Errorf("%s: %w", fh.Name(), err)
 	}
 	return nil
 }
 
-var errMissingFields = xerrors.New("missing fields")
+var errMissingFields = errors.New("missing fields")
 
 func scanFdInfoReader(r io.Reader, fields map[string]interface{}) error {
 	var (
@@ -179,7 +178,7 @@ func scanFdInfoReader(r io.Reader, fields map[string]interface{}) error {
 		}
 
 		if n, err := fmt.Fscanln(bytes.NewReader(parts[1]), field); err != nil || n != 1 {
-			return xerrors.Errorf("can't parse field %s: %v", name, err)
+			return fmt.Errorf("can't parse field %s: %v", name, err)
 		}
 
 		scanned++

--- a/collection.go
+++ b/collection.go
@@ -1,12 +1,13 @@
 package ebpf
 
 import (
+	"errors"
+	"fmt"
 	"math"
 
 	"github.com/DataDog/ebpf/asm"
 	"github.com/DataDog/ebpf/internal"
 	"github.com/DataDog/ebpf/internal/btf"
-	"golang.org/x/xerrors"
 )
 
 // CollectionOptions control loading a collection into the kernel.
@@ -64,12 +65,12 @@ func (cs *CollectionSpec) RewriteMaps(maps map[string]*Map) error {
 				// Not all programs need to use the map
 
 			default:
-				return xerrors.Errorf("program %s: %w", progName, err)
+				return fmt.Errorf("program %s: %w", progName, err)
 			}
 		}
 
 		if !seen {
-			return xerrors.Errorf("map %s not referenced by any programs", symbol)
+			return fmt.Errorf("map %s not referenced by any programs", symbol)
 		}
 
 		// Prevent NewCollection from creating rewritten maps
@@ -96,21 +97,21 @@ func (cs *CollectionSpec) RewriteMaps(maps map[string]*Map) error {
 func (cs *CollectionSpec) RewriteConstants(consts map[string]interface{}) error {
 	rodata := cs.Maps[".rodata"]
 	if rodata == nil {
-		return xerrors.New("missing .rodata section")
+		return errors.New("missing .rodata section")
 	}
 
 	if rodata.BTF == nil {
-		return xerrors.New(".rodata section has no BTF")
+		return errors.New(".rodata section has no BTF")
 	}
 
 	if n := len(rodata.Contents); n != 1 {
-		return xerrors.Errorf("expected one key in .rodata, found %d", n)
+		return fmt.Errorf("expected one key in .rodata, found %d", n)
 	}
 
 	kv := rodata.Contents[0]
 	value, ok := kv.Value.([]byte)
 	if !ok {
-		return xerrors.Errorf("first value in .rodata is %T not []byte", kv.Value)
+		return fmt.Errorf("first value in .rodata is %T not []byte", kv.Value)
 	}
 
 	buf := make([]byte, len(value))
@@ -185,14 +186,14 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (col
 		var handle *btf.Handle
 		if mapSpec.BTF != nil {
 			handle, err = loadBTF(btf.MapSpec(mapSpec.BTF))
-			if err != nil && !xerrors.Is(err, btf.ErrNotSupported) {
+			if err != nil && !errors.Is(err, btf.ErrNotSupported) {
 				return nil, err
 			}
 		}
 
 		m, err := newMapWithBTF(mapSpec, handle)
 		if err != nil {
-			return nil, xerrors.Errorf("map %s: %w", mapName, err)
+			return nil, fmt.Errorf("map %s: %w", mapName, err)
 		}
 		maps[mapName] = m
 	}
@@ -216,29 +217,29 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (col
 
 			m := maps[ins.Reference]
 			if m == nil {
-				return nil, xerrors.Errorf("program %s: missing map %s", progName, ins.Reference)
+				return nil, fmt.Errorf("program %s: missing map %s", progName, ins.Reference)
 			}
 
 			fd := m.FD()
 			if fd < 0 {
-				return nil, xerrors.Errorf("map %s: %w", ins.Reference, internal.ErrClosedFd)
+				return nil, fmt.Errorf("map %s: %w", ins.Reference, internal.ErrClosedFd)
 			}
 			if err := ins.RewriteMapPtr(m.FD()); err != nil {
-				return nil, xerrors.Errorf("progam %s: map %s: %w", progName, ins.Reference, err)
+				return nil, fmt.Errorf("progam %s: map %s: %w", progName, ins.Reference, err)
 			}
 		}
 
 		var handle *btf.Handle
 		if progSpec.BTF != nil {
 			handle, err = loadBTF(btf.ProgramSpec(progSpec.BTF))
-			if err != nil && !xerrors.Is(err, btf.ErrNotSupported) {
+			if err != nil && !errors.Is(err, btf.ErrNotSupported) {
 				return nil, err
 			}
 		}
 
 		prog, err := newProgramWithBTF(progSpec, handle, opts.Programs)
 		if err != nil {
-			return nil, xerrors.Errorf("program %s: %w", progName, err)
+			return nil, fmt.Errorf("program %s: %w", progName, err)
 		}
 		progs[progName] = prog
 	}

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"debug/elf"
 	"encoding/binary"
+	"fmt"
 	"github.com/pkg/errors"
 	"io"
 	"math"
@@ -14,8 +15,6 @@ import (
 	"github.com/DataDog/ebpf/internal"
 	"github.com/DataDog/ebpf/internal/btf"
 	"github.com/DataDog/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -40,7 +39,7 @@ func LoadCollectionSpec(file string) (*CollectionSpec, error) {
 
 	spec, err := LoadCollectionSpecFromReader(f)
 	if err != nil {
-		return nil, xerrors.Errorf("file %s: %w", file, err)
+		return nil, fmt.Errorf("file %s: %w", file, err)
 	}
 	return spec, nil
 }
@@ -55,7 +54,7 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 	symbols, err := f.Symbols()
 	if err != nil {
-		return nil, xerrors.Errorf("load symbols: %v", err)
+		return nil, fmt.Errorf("load symbols: %v", err)
 	}
 
 	ec := &elfCode{f, symbols, symbolsPerSection(symbols), "", 0}
@@ -84,13 +83,13 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 			dataSections[elf.SectionIndex(i)] = sec
 		case sec.Type == elf.SHT_REL:
 			if int(sec.Info) >= len(ec.Sections) {
-				return nil, xerrors.Errorf("found relocation section %v for missing section %v", i, sec.Info)
+				return nil, fmt.Errorf("found relocation section %v for missing section %v", i, sec.Info)
 			}
 
 			// Store relocations under the section index of the target
 			idx := elf.SectionIndex(sec.Info)
 			if relSections[idx] != nil {
-				return nil, xerrors.Errorf("section %d has multiple relocation sections", sec.Info)
+				return nil, fmt.Errorf("section %d has multiple relocation sections", sec.Info)
 			}
 			relSections[idx] = sec
 		case sec.Type == elf.SHT_PROGBITS && (sec.Flags&elf.SHF_EXECINSTR) != 0 && sec.Size > 0:
@@ -100,12 +99,12 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 	ec.license, err = loadLicense(licenseSection)
 	if err != nil {
-		return nil, xerrors.Errorf("load license: %w", err)
+		return nil, fmt.Errorf("load license: %w", err)
 	}
 
 	ec.version, err = loadVersion(versionSection, ec.ByteOrder)
 	if err != nil {
-		return nil, xerrors.Errorf("load version: %w", err)
+		return nil, fmt.Errorf("load version: %w", err)
 	}
 	if ec.version == useCurrentKernelVersion {
 		ec.version, err = CurrentKernelVersion()
@@ -116,34 +115,34 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 	btfSpec, err := btf.LoadSpecFromReader(rd)
 	if err != nil {
-		return nil, xerrors.Errorf("load BTF: %w", err)
+		return nil, fmt.Errorf("load BTF: %w", err)
 	}
 
 	maps := make(map[string]*MapSpec)
 	if err := ec.loadMaps(maps, mapSections); err != nil {
-		return nil, xerrors.Errorf("load maps: %w", err)
+		return nil, fmt.Errorf("load maps: %w", err)
 	}
 
 	if len(btfMaps) > 0 {
 		if err := ec.loadBTFMaps(maps, btfMaps, btfSpec); err != nil {
-			return nil, xerrors.Errorf("load BTF maps: %w", err)
+			return nil, fmt.Errorf("load BTF maps: %w", err)
 		}
 	}
 
 	if len(dataSections) > 0 {
 		if err := ec.loadDataSections(maps, dataSections, btfSpec); err != nil {
-			return nil, xerrors.Errorf("load data sections: %w", err)
+			return nil, fmt.Errorf("load data sections: %w", err)
 		}
 	}
 
 	relocations, err := ec.loadRelocations(relSections)
 	if err != nil {
-		return nil, xerrors.Errorf("load relocations: %w", err)
+		return nil, fmt.Errorf("load relocations: %w", err)
 	}
 
 	progs, err := ec.loadPrograms(progSections, relocations, btfSpec)
 	if err != nil {
-		return nil, xerrors.Errorf("load programs: %w", err)
+		return nil, fmt.Errorf("load programs: %w", err)
 	}
 
 	return &CollectionSpec{maps, progs}, nil
@@ -151,11 +150,11 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 func loadLicense(sec *elf.Section) (string, error) {
 	if sec == nil {
-		return "", xerrors.New("missing license section")
+		return "", errors.New("missing license section")
 	}
 	data, err := sec.Data()
 	if err != nil {
-		return "", xerrors.Errorf("section %s: %v", sec.Name, err)
+		return "", fmt.Errorf("section %s: %v", sec.Name, err)
 	}
 	return string(bytes.TrimRight(data, "\000")), nil
 }
@@ -167,7 +166,7 @@ func loadVersion(sec *elf.Section, bo binary.ByteOrder) (uint32, error) {
 
 	var version uint32
 	if err := binary.Read(sec.Open(), bo, &version); err != nil {
-		return 0, xerrors.Errorf("section %s: %v", sec.Name, err)
+		return 0, fmt.Errorf("section %s: %v", sec.Name, err)
 	}
 	return version, nil
 }
@@ -181,17 +180,17 @@ func (ec *elfCode) loadPrograms(progSections map[elf.SectionIndex]*elf.Section, 
 	for idx, sec := range progSections {
 		syms := ec.symbolsPerSection[idx]
 		if len(syms) == 0 {
-			return nil, xerrors.Errorf("section %v: missing symbols", sec.Name)
+			return nil, fmt.Errorf("section %v: missing symbols", sec.Name)
 		}
 
 		funcSym, ok := syms[0]
 		if !ok {
-			return nil, xerrors.Errorf("section %v: no label at start", sec.Name)
+			return nil, fmt.Errorf("section %v: no label at start", sec.Name)
 		}
 
 		insns, length, err := ec.loadInstructions(sec, syms, relocations[idx])
 		if err != nil {
-			return nil, xerrors.Errorf("program %s: can't unmarshal instructions: %w", funcSym.Name, err)
+			return nil, fmt.Errorf("program %s: can't unmarshal instructions: %w", funcSym.Name, err)
 		}
 
 		progType, attachType := getProgType(sec.Name)
@@ -210,7 +209,7 @@ func (ec *elfCode) loadPrograms(progSections map[elf.SectionIndex]*elf.Section, 
 		if btf != nil {
 			spec.BTF, err = btf.Program(sec.Name, length)
 			if err != nil {
-				return nil, xerrors.Errorf("BTF for section %s (program %s): %w", sec.Name, funcSym.Name, err)
+				return nil, fmt.Errorf("BTF for section %s (program %s): %w", sec.Name, funcSym.Name, err)
 			}
 		}
 
@@ -228,7 +227,7 @@ func (ec *elfCode) loadPrograms(progSections map[elf.SectionIndex]*elf.Section, 
 	for _, prog := range progs {
 		err := link(prog, libs)
 		if err != nil {
-			return nil, xerrors.Errorf("program %s: %w", prog.Name, err)
+			return nil, fmt.Errorf("program %s: %w", prog.Name, err)
 		}
 		// Indexing by section names makes things much easier when it comes to selecting programs. Just like the
 		// function names, the section names are unique per ".o" so we won't have a conflict.
@@ -251,14 +250,14 @@ func (ec *elfCode) loadInstructions(section *elf.Section, symbols, relocations m
 			return insns, offset, nil
 		}
 		if err != nil {
-			return nil, 0, xerrors.Errorf("offset %d: %w", offset, err)
+			return nil, 0, fmt.Errorf("offset %d: %w", offset, err)
 		}
 
 		ins.Symbol = symbols[offset].Name
 
 		if rel, ok := relocations[offset]; ok {
 			if err = ec.relocateInstruction(&ins, rel); err != nil {
-				return nil, 0, xerrors.Errorf("offset %d: can't relocate instruction: %w", offset, err)
+				return nil, 0, fmt.Errorf("offset %d: can't relocate instruction: %w", offset, err)
 			}
 		}
 
@@ -279,7 +278,7 @@ func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) err
 		// from the section itself.
 		idx := int(rel.Section)
 		if idx > len(ec.Sections) {
-			return xerrors.New("out-of-bounds section index")
+			return errors.New("out-of-bounds section index")
 		}
 
 		name = ec.Sections[idx].Name
@@ -299,7 +298,7 @@ outer:
 			// section. Weirdly, the offset of the real symbol in the
 			// section is encoded in the instruction stream.
 			if bind != elf.STB_LOCAL {
-				return xerrors.Errorf("direct load: %s: unsupported relocation %s", name, bind)
+				return fmt.Errorf("direct load: %s: unsupported relocation %s", name, bind)
 			}
 
 			// For some reason, clang encodes the offset of the symbol its
@@ -321,13 +320,13 @@ outer:
 
 		case elf.STT_OBJECT:
 			if bind != elf.STB_GLOBAL {
-				return xerrors.Errorf("load: %s: unsupported binding: %s", name, bind)
+				return fmt.Errorf("load: %s: unsupported binding: %s", name, bind)
 			}
 
 			ins.Src = asm.PseudoMapFD
 
 		default:
-			return xerrors.Errorf("load: %s: unsupported relocation: %s", name, typ)
+			return fmt.Errorf("load: %s: unsupported relocation: %s", name, typ)
 		}
 
 		// Mark the instruction as needing an update when creating the
@@ -338,18 +337,18 @@ outer:
 
 	case ins.OpCode.JumpOp() == asm.Call:
 		if ins.Src != asm.PseudoCall {
-			return xerrors.Errorf("call: %s: incorrect source register", name)
+			return fmt.Errorf("call: %s: incorrect source register", name)
 		}
 
 		switch typ {
 		case elf.STT_NOTYPE, elf.STT_FUNC:
 			if bind != elf.STB_GLOBAL {
-				return xerrors.Errorf("call: %s: unsupported binding: %s", name, bind)
+				return fmt.Errorf("call: %s: unsupported binding: %s", name, bind)
 			}
 
 		case elf.STT_SECTION:
 			if bind != elf.STB_LOCAL {
-				return xerrors.Errorf("call: %s: unsupported binding: %s", name, bind)
+				return fmt.Errorf("call: %s: unsupported binding: %s", name, bind)
 			}
 
 			// The function we want to call is in the indicated section,
@@ -358,23 +357,23 @@ outer:
 			// A value of -1 references the first instruction in the section.
 			offset := int64(int32(ins.Constant)+1) * asm.InstructionSize
 			if offset < 0 {
-				return xerrors.Errorf("call: %s: invalid offset %d", name, offset)
+				return fmt.Errorf("call: %s: invalid offset %d", name, offset)
 			}
 
 			sym, ok := ec.symbolsPerSection[rel.Section][uint64(offset)]
 			if !ok {
-				return xerrors.Errorf("call: %s: no symbol at offset %d", name, offset)
+				return fmt.Errorf("call: %s: no symbol at offset %d", name, offset)
 			}
 
 			ins.Constant = -1
 			name = sym.Name
 
 		default:
-			return xerrors.Errorf("call: %s: invalid symbol type %s", name, typ)
+			return fmt.Errorf("call: %s: invalid symbol type %s", name, typ)
 		}
 
 	default:
-		return xerrors.Errorf("relocation for unsupported instruction: %s", ins.OpCode)
+		return fmt.Errorf("relocation for unsupported instruction: %s", ins.OpCode)
 	}
 
 	ins.Reference = name
@@ -385,26 +384,26 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 	for idx, sec := range mapSections {
 		syms := ec.symbolsPerSection[idx]
 		if len(syms) == 0 {
-			return xerrors.Errorf("section %v: no symbols", sec.Name)
+			return fmt.Errorf("section %v: no symbols", sec.Name)
 		}
 
 		if sec.Size%uint64(len(syms)) != 0 {
-			return xerrors.Errorf("section %v: map descriptors are not of equal size", sec.Name)
+			return fmt.Errorf("section %v: map descriptors are not of equal size", sec.Name)
 		}
 
 		var (
-			r    = sec.Open()
-			size = sec.Size / uint64(len(syms))
+			r       = sec.Open()
+			size    = sec.Size / uint64(len(syms))
 			ordered []*MapSpec
 		)
 		for i, offset := 0, uint64(0); i < len(syms); i, offset = i+1, offset+size {
 			mapSym, ok := syms[offset]
 			if !ok {
-				return xerrors.Errorf("section %s: missing symbol for map at offset %d", sec.Name, offset)
+				return fmt.Errorf("section %s: missing symbol for map at offset %d", sec.Name, offset)
 			}
 
 			if maps[mapSym.Name] != nil {
-				return xerrors.Errorf("section %v: map %v already exists", sec.Name, mapSym)
+				return fmt.Errorf("section %v: map %v already exists", sec.Name, mapSym)
 			}
 
 			lr := io.LimitReader(r, int64(size))
@@ -412,34 +411,34 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 			spec := MapSpec{
 				Name: SanitizeName(mapSym.Name, -1),
 			}
-			var inner uint32
+			var inner uint32 = math.MaxUint32
 			switch {
 			case binary.Read(lr, ec.ByteOrder, &spec.Type) != nil:
-				return xerrors.Errorf("map %v: missing type", mapSym)
+				return fmt.Errorf("map %v: missing type", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.KeySize) != nil:
-				return xerrors.Errorf("map %v: missing key size", mapSym)
+				return fmt.Errorf("map %v: missing key size", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.ValueSize) != nil:
-				return xerrors.Errorf("map %v: missing value size", mapSym)
+				return fmt.Errorf("map %v: missing value size", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.MaxEntries) != nil:
-				return xerrors.Errorf("map %v: missing max entries", mapSym)
+				return fmt.Errorf("map %v: missing max entries", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.Flags) != nil:
-				return xerrors.Errorf("map %v: missing flags", mapSym)
+				return fmt.Errorf("map %v: missing flags", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &inner) != nil:
-				return xerrors.Errorf("map %v: can't read inner map index", mapSym)
+				return fmt.Errorf("map %v: can't read inner map index", mapSym)
 			}
 
 			if _, err := io.Copy(internal.DiscardZeroes{}, lr); err != nil {
-				return xerrors.Errorf("map %v: unknown and non-zero fields in definition", mapSym)
+				return fmt.Errorf("map %v: unknown and non-zero fields in definition", mapSym)
 			}
 
 			if spec.Type == ArrayOfMaps || spec.Type == HashOfMaps {
 				if int(inner) > len(ordered) {
-					return xerrors.Errorf("map %v: invalid inner map index %d", mapSym, inner)
+					return fmt.Errorf("map %v: invalid inner map index %d", mapSym, inner)
 				}
 
 				innerSpec := ordered[int(inner)]
 				if innerSpec.InnerMap != nil {
-					return xerrors.Errorf("map %v: can't nest map of map", mapSym)
+					return fmt.Errorf("map %v: can't nest map of map", mapSym)
 				}
 				spec.InnerMap = innerSpec.Copy()
 			}
@@ -454,29 +453,29 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 
 func (ec *elfCode) loadBTFMaps(maps map[string]*MapSpec, mapSections map[elf.SectionIndex]*elf.Section, spec *btf.Spec) error {
 	if spec == nil {
-		return xerrors.Errorf("missing BTF")
+		return fmt.Errorf("missing BTF")
 	}
 
 	for idx, sec := range mapSections {
 		syms := ec.symbolsPerSection[idx]
 		if len(syms) == 0 {
-			return xerrors.Errorf("section %v: no symbols", sec.Name)
+			return fmt.Errorf("section %v: no symbols", sec.Name)
 		}
 
 		for _, sym := range syms {
 			name := sym.Name
 			if maps[name] != nil {
-				return xerrors.Errorf("section %v: map %v already exists", sec.Name, sym)
+				return fmt.Errorf("section %v: map %v already exists", sec.Name, sym)
 			}
 
 			btfMap, btfMapMembers, err := spec.Map(name)
 			if err != nil {
-				return xerrors.Errorf("map %v: can't get BTF: %w", name, err)
+				return fmt.Errorf("map %v: can't get BTF: %w", name, err)
 			}
 
 			spec, err := mapSpecFromBTF(btfMap, btfMapMembers)
 			if err != nil {
-				return xerrors.Errorf("map %v: %w", name, err)
+				return fmt.Errorf("map %v: %w", name, err)
 			}
 
 			maps[name] = spec
@@ -496,36 +495,36 @@ func mapSpecFromBTF(btfMap *btf.Map, btfMapMembers []btf.Member) (*MapSpec, erro
 		case "type":
 			mapType, err = uintFromBTF(member.Type)
 			if err != nil {
-				return nil, xerrors.Errorf("can't get type: %w", err)
+				return nil, fmt.Errorf("can't get type: %w", err)
 			}
 
 		case "map_flags":
 			flags, err = uintFromBTF(member.Type)
 			if err != nil {
-				return nil, xerrors.Errorf("can't get BTF map flags: %w", err)
+				return nil, fmt.Errorf("can't get BTF map flags: %w", err)
 			}
 
 		case "max_entries":
 			maxEntries, err = uintFromBTF(member.Type)
 			if err != nil {
-				return nil, xerrors.Errorf("can't get BTF map max entries: %w", err)
+				return nil, fmt.Errorf("can't get BTF map max entries: %w", err)
 			}
 
 		case "key":
 		case "value":
 		default:
-			return nil, xerrors.Errorf("unrecognized field %s in BTF map definition", member.Name)
+			return nil, fmt.Errorf("unrecognized field %s in BTF map definition", member.Name)
 		}
 	}
 
 	keySize, err := btf.Sizeof(btf.MapKey(btfMap))
 	if err != nil {
-		return nil, xerrors.Errorf("can't get size of BTF key: %w", err)
+		return nil, fmt.Errorf("can't get size of BTF key: %w", err)
 	}
 
 	valueSize, err := btf.Sizeof(btf.MapValue(btfMap))
 	if err != nil {
-		return nil, xerrors.Errorf("can't get size of BTF value: %w", err)
+		return nil, fmt.Errorf("can't get size of BTF value: %w", err)
 	}
 
 	return &MapSpec{
@@ -543,12 +542,12 @@ func mapSpecFromBTF(btfMap *btf.Map, btfMapMembers []btf.Member) (*MapSpec, erro
 func uintFromBTF(typ btf.Type) (uint32, error) {
 	ptr, ok := typ.(*btf.Pointer)
 	if !ok {
-		return 0, xerrors.Errorf("not a pointer: %v", typ)
+		return 0, fmt.Errorf("not a pointer: %v", typ)
 	}
 
 	arr, ok := ptr.Target.(*btf.Array)
 	if !ok {
-		return 0, xerrors.Errorf("not a pointer to array: %v", typ)
+		return 0, fmt.Errorf("not a pointer to array: %v", typ)
 	}
 
 	return arr.Nelems, nil
@@ -556,7 +555,7 @@ func uintFromBTF(typ btf.Type) (uint32, error) {
 
 func (ec *elfCode) loadDataSections(maps map[string]*MapSpec, dataSections map[elf.SectionIndex]*elf.Section, spec *btf.Spec) error {
 	if spec == nil {
-		return xerrors.New("data sections require BTF")
+		return errors.New("data sections require BTF")
 	}
 
 	for _, sec := range dataSections {
@@ -567,11 +566,11 @@ func (ec *elfCode) loadDataSections(maps map[string]*MapSpec, dataSections map[e
 
 		data, err := sec.Data()
 		if err != nil {
-			return xerrors.Errorf("data section %s: can't get contents: %w", sec.Name, err)
+			return fmt.Errorf("data section %s: can't get contents: %w", sec.Name, err)
 		}
 
 		if uint64(len(data)) > math.MaxUint32 {
-			return xerrors.Errorf("data section %s: contents exceed maximum size", sec.Name)
+			return fmt.Errorf("data section %s: contents exceed maximum size", sec.Name)
 		}
 
 		mapSpec := &MapSpec{
@@ -682,7 +681,7 @@ func (ec *elfCode) loadRelocations(sections map[elf.SectionIndex]*elf.Section) (
 		rels := make(map[uint64]elf.Symbol)
 
 		if sec.Entsize < 16 {
-			return nil, xerrors.Errorf("section %s: relocations are less than 16 bytes", sec.Name)
+			return nil, fmt.Errorf("section %s: relocations are less than 16 bytes", sec.Name)
 		}
 
 		r := sec.Open()
@@ -691,12 +690,12 @@ func (ec *elfCode) loadRelocations(sections map[elf.SectionIndex]*elf.Section) (
 
 			var rel elf.Rel64
 			if binary.Read(ent, ec.ByteOrder, &rel) != nil {
-				return nil, xerrors.Errorf("can't parse relocation at offset %v", off)
+				return nil, fmt.Errorf("can't parse relocation at offset %v", off)
 			}
 
 			symNo := int(elf.R_SYM64(rel.Info) - 1)
 			if symNo >= len(ec.symbols) {
-				return nil, xerrors.Errorf("relocation at offset %d: symbol %v doesnt exist", off, symNo)
+				return nil, fmt.Errorf("relocation at offset %d: symbol %v doesnt exist", off, symNo)
 			}
 
 			rels[rel.Off] = ec.symbols[symNo]

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,4 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/sys v0.0.0-20200320181252-af34d8274f85
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/internal/btf/btf_types.go
+++ b/internal/btf/btf_types.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-
-	"golang.org/x/xerrors"
 )
 
 // btfKind describes a Type.
@@ -199,7 +197,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		if err := binary.Read(r, bo, &header); err == io.EOF {
 			return types, nil
 		} else if err != nil {
-			return nil, xerrors.Errorf("can't read type info for id %v: %v", id, err)
+			return nil, fmt.Errorf("can't read type info for id %v: %v", id, err)
 		}
 
 		var data interface{}
@@ -228,7 +226,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		case kindDatasec:
 			data = make([]btfVarSecinfo, header.Vlen())
 		default:
-			return nil, xerrors.Errorf("type id %v: unknown kind: %v", id, header.Kind())
+			return nil, fmt.Errorf("type id %v: unknown kind: %v", id, header.Kind())
 		}
 
 		if data == nil {
@@ -237,7 +235,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		}
 
 		if err := binary.Read(r, bo, data); err != nil {
-			return nil, xerrors.Errorf("type id %d: kind %v: can't read %T: %v", id, header.Kind(), data, err)
+			return nil, fmt.Errorf("type id %d: kind %v: can't read %T: %v", id, header.Kind(), data, err)
 		}
 
 		types = append(types, rawType{header, data})

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -3,13 +3,13 @@ package btf
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 
 	"github.com/DataDog/ebpf/asm"
 	"github.com/DataDog/ebpf/internal"
-
-	"golang.org/x/xerrors"
 )
 
 type btfExtHeader struct {
@@ -27,49 +27,49 @@ type btfExtHeader struct {
 func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (funcInfo, lineInfo map[string]extInfo, err error) {
 	var header btfExtHeader
 	if err := binary.Read(r, bo, &header); err != nil {
-		return nil, nil, xerrors.Errorf("can't read header: %v", err)
+		return nil, nil, fmt.Errorf("can't read header: %v", err)
 	}
 
 	if header.Magic != btfMagic {
-		return nil, nil, xerrors.Errorf("incorrect magic value %v", header.Magic)
+		return nil, nil, fmt.Errorf("incorrect magic value %v", header.Magic)
 	}
 
 	if header.Version != 1 {
-		return nil, nil, xerrors.Errorf("unexpected version %v", header.Version)
+		return nil, nil, fmt.Errorf("unexpected version %v", header.Version)
 	}
 
 	if header.Flags != 0 {
-		return nil, nil, xerrors.Errorf("unsupported flags %v", header.Flags)
+		return nil, nil, fmt.Errorf("unsupported flags %v", header.Flags)
 	}
 
 	remainder := int64(header.HdrLen) - int64(binary.Size(&header))
 	if remainder < 0 {
-		return nil, nil, xerrors.New("header is too short")
+		return nil, nil, errors.New("header is too short")
 	}
 
 	// Of course, the .BTF.ext header has different semantics than the
 	// .BTF ext header. We need to ignore non-null values.
 	_, err = io.CopyN(ioutil.Discard, r, remainder)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("header padding: %v", err)
+		return nil, nil, fmt.Errorf("header padding: %v", err)
 	}
 
 	if _, err := r.Seek(int64(header.HdrLen+header.FuncInfoOff), io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("can't seek to function info section: %v", err)
+		return nil, nil, fmt.Errorf("can't seek to function info section: %v", err)
 	}
 
 	funcInfo, err = parseExtInfo(io.LimitReader(r, int64(header.FuncInfoLen)), bo, strings)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("function info: %w", err)
+		return nil, nil, fmt.Errorf("function info: %w", err)
 	}
 
 	if _, err := r.Seek(int64(header.HdrLen+header.LineInfoOff), io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("can't seek to line info section: %v", err)
+		return nil, nil, fmt.Errorf("can't seek to line info section: %v", err)
 	}
 
 	lineInfo, err = parseExtInfo(io.LimitReader(r, int64(header.LineInfoLen)), bo, strings)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("line info: %w", err)
+		return nil, nil, fmt.Errorf("line info: %w", err)
 	}
 
 	return funcInfo, lineInfo, nil
@@ -92,7 +92,7 @@ type extInfo struct {
 
 func (ei extInfo) append(other extInfo, offset uint64) (extInfo, error) {
 	if other.recordSize != ei.recordSize {
-		return extInfo{}, xerrors.Errorf("ext_info record size mismatch, want %d (got %d)", ei.recordSize, other.recordSize)
+		return extInfo{}, fmt.Errorf("ext_info record size mismatch, want %d (got %d)", ei.recordSize, other.recordSize)
 	}
 
 	records := make([]extInfoRecord, 0, len(ei.records)+len(other.records))
@@ -117,7 +117,7 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 		// while the ELF tracks it in bytes.
 		insnOff := uint32(info.InsnOff / asm.InstructionSize)
 		if err := binary.Write(buf, internal.NativeEndian, insnOff); err != nil {
-			return nil, xerrors.Errorf("can't write instruction offset: %v", err)
+			return nil, fmt.Errorf("can't write instruction offset: %v", err)
 		}
 
 		buf.Write(info.Opaque)
@@ -129,12 +129,12 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[string]extInfo, error) {
 	var recordSize uint32
 	if err := binary.Read(r, bo, &recordSize); err != nil {
-		return nil, xerrors.Errorf("can't read record size: %v", err)
+		return nil, fmt.Errorf("can't read record size: %v", err)
 	}
 
 	if recordSize < 4 {
 		// Need at least insnOff
-		return nil, xerrors.New("record size too short")
+		return nil, errors.New("record size too short")
 	}
 
 	result := make(map[string]extInfo)
@@ -143,32 +143,32 @@ func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[st
 		if err := binary.Read(r, bo, &infoHeader); err == io.EOF {
 			return result, nil
 		} else if err != nil {
-			return nil, xerrors.Errorf("can't read ext info header: %v", err)
+			return nil, fmt.Errorf("can't read ext info header: %v", err)
 		}
 
 		secName, err := strings.Lookup(infoHeader.SecNameOff)
 		if err != nil {
-			return nil, xerrors.Errorf("can't get section name: %w", err)
+			return nil, fmt.Errorf("can't get section name: %w", err)
 		}
 
 		if infoHeader.NumInfo == 0 {
-			return nil, xerrors.Errorf("section %s has invalid number of records", secName)
+			return nil, fmt.Errorf("section %s has invalid number of records", secName)
 		}
 
 		var records []extInfoRecord
 		for i := uint32(0); i < infoHeader.NumInfo; i++ {
 			var byteOff uint32
 			if err := binary.Read(r, bo, &byteOff); err != nil {
-				return nil, xerrors.Errorf("section %v: can't read extended info offset: %v", secName, err)
+				return nil, fmt.Errorf("section %v: can't read extended info offset: %v", secName, err)
 			}
 
 			buf := make([]byte, int(recordSize-4))
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, xerrors.Errorf("section %v: can't read record: %v", secName, err)
+				return nil, fmt.Errorf("section %v: can't read record: %v", secName, err)
 			}
 
 			if byteOff%asm.InstructionSize != 0 {
-				return nil, xerrors.Errorf("section %v: offset %v is not aligned with instruction size", secName, byteOff)
+				return nil, fmt.Errorf("section %v: offset %v is not aligned with instruction size", secName, byteOff)
 			}
 
 			records = append(records, extInfoRecord{uint64(byteOff), buf})

--- a/internal/btf/strings.go
+++ b/internal/btf/strings.go
@@ -2,10 +2,10 @@ package btf
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
-
-	"golang.org/x/xerrors"
 )
 
 type stringTable []byte
@@ -13,19 +13,19 @@ type stringTable []byte
 func readStringTable(r io.Reader) (stringTable, error) {
 	contents, err := ioutil.ReadAll(r)
 	if err != nil {
-		return nil, xerrors.Errorf("can't read string table: %v", err)
+		return nil, fmt.Errorf("can't read string table: %v", err)
 	}
 
 	if len(contents) < 1 {
-		return nil, xerrors.New("string table is empty")
+		return nil, errors.New("string table is empty")
 	}
 
 	if contents[0] != '\x00' {
-		return nil, xerrors.New("first item in string table is non-empty")
+		return nil, errors.New("first item in string table is non-empty")
 	}
 
 	if contents[len(contents)-1] != '\x00' {
-		return nil, xerrors.New("string table isn't null terminated")
+		return nil, errors.New("string table isn't null terminated")
 	}
 
 	return stringTable(contents), nil
@@ -33,22 +33,22 @@ func readStringTable(r io.Reader) (stringTable, error) {
 
 func (st stringTable) Lookup(offset uint32) (string, error) {
 	if int64(offset) > int64(^uint(0)>>1) {
-		return "", xerrors.Errorf("offset %d overflows int", offset)
+		return "", fmt.Errorf("offset %d overflows int", offset)
 	}
 
 	pos := int(offset)
 	if pos >= len(st) {
-		return "", xerrors.Errorf("offset %d is out of bounds", offset)
+		return "", fmt.Errorf("offset %d is out of bounds", offset)
 	}
 
 	if pos > 0 && st[pos-1] != '\x00' {
-		return "", xerrors.Errorf("offset %d isn't start of a string", offset)
+		return "", fmt.Errorf("offset %d isn't start of a string", offset)
 	}
 
 	str := st[pos:]
 	end := bytes.IndexByte(str, '\x00')
 	if end == -1 {
-		return "", xerrors.Errorf("offset %d isn't null terminated", offset)
+		return "", fmt.Errorf("offset %d isn't null terminated", offset)
 	}
 
 	return string(str[:end]), nil

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -1,9 +1,9 @@
 package btf
 
 import (
+	"errors"
+	"fmt"
 	"math"
-
-	"golang.org/x/xerrors"
 )
 
 const maxTypeDepth = 32
@@ -310,7 +310,7 @@ func Sizeof(typ Type) (int, error) {
 		switch v := typ.(type) {
 		case *Array:
 			if n > 0 && int64(v.Nelems) > math.MaxInt64/n {
-				return 0, xerrors.New("overflow")
+				return 0, errors.New("overflow")
 			}
 
 			// Arrays may be of zero length, which allows
@@ -336,22 +336,22 @@ func Sizeof(typ Type) (int, error) {
 			continue
 
 		default:
-			return 0, xerrors.Errorf("unrecognized type %T", typ)
+			return 0, fmt.Errorf("unrecognized type %T", typ)
 		}
 
 		if n > 0 && elem > math.MaxInt64/n {
-			return 0, xerrors.New("overflow")
+			return 0, errors.New("overflow")
 		}
 
 		size := n * elem
 		if int64(int(size)) != size {
-			return 0, xerrors.New("overflow")
+			return 0, errors.New("overflow")
 		}
 
 		return int(size), nil
 	}
 
-	return 0, xerrors.New("exceeded type depth")
+	return 0, errors.New("exceeded type depth")
 }
 
 // copy a Type recursively.
@@ -433,7 +433,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (namedTypes map
 		for i, btfMember := range raw {
 			name, err := rawStrings.LookupName(btfMember.NameOff)
 			if err != nil {
-				return nil, xerrors.Errorf("can't get name for member %d: %w", i, err)
+				return nil, fmt.Errorf("can't get name for member %d: %w", i, err)
 			}
 			members = append(members, Member{
 				Name:   name,
@@ -460,7 +460,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (namedTypes map
 
 		name, err := rawStrings.LookupName(raw.NameOff)
 		if err != nil {
-			return nil, xerrors.Errorf("can't get name for type id %d: %w", id, err)
+			return nil, fmt.Errorf("can't get name for type id %d: %w", id, err)
 		}
 
 		switch raw.Kind() {
@@ -484,14 +484,14 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (namedTypes map
 		case kindStruct:
 			members, err := convertMembers(raw.data.([]btfMember))
 			if err != nil {
-				return nil, xerrors.Errorf("struct %s (id %d): %w", name, id, err)
+				return nil, fmt.Errorf("struct %s (id %d): %w", name, id, err)
 			}
 			typ = &Struct{id, name, raw.Size(), members}
 
 		case kindUnion:
 			members, err := convertMembers(raw.data.([]btfMember))
 			if err != nil {
-				return nil, xerrors.Errorf("union %s (id %d): %w", name, id, err)
+				return nil, fmt.Errorf("union %s (id %d): %w", name, id, err)
 			}
 			typ = &Union{id, name, raw.Size(), members}
 
@@ -551,7 +551,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (namedTypes map
 			typ = &Datasec{id, name, raw.SizeType, vars}
 
 		default:
-			return nil, xerrors.Errorf("type id %d: unknown kind: %v", id, raw.Kind())
+			return nil, fmt.Errorf("type id %d: unknown kind: %v", id, raw.Kind())
 		}
 
 		types = append(types, typ)
@@ -566,7 +566,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (namedTypes map
 	for _, fixup := range fixups {
 		i := int(fixup.id)
 		if i >= len(types) {
-			return nil, xerrors.Errorf("reference to invalid type id: %d", fixup.id)
+			return nil, fmt.Errorf("reference to invalid type id: %d", fixup.id)
 		}
 
 		// Default void (id 0) to unknown
@@ -576,7 +576,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (namedTypes map
 		}
 
 		if expected := fixup.expectedKind; expected != kindUnknown && rawKind != expected {
-			return nil, xerrors.Errorf("expected type id %d to have kind %s, found %s", fixup.id, expected, rawKind)
+			return nil, fmt.Errorf("expected type id %d to have kind %s, found %s", fixup.id, expected, rawKind)
 		}
 
 		*fixup.typ = types[i]

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -2,11 +2,11 @@ package internal
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/DataDog/ebpf/internal/unix"
-	"golang.org/x/xerrors"
 )
 
 // ErrorWithLog returns an error that includes logs from the
@@ -16,7 +16,7 @@ import (
 // the log. It is used to check for truncation of the output.
 func ErrorWithLog(err error, log []byte, logErr error) error {
 	logStr := strings.Trim(CString(log), "\t\r\n ")
-	if xerrors.Is(logErr, unix.ENOSPC) {
+	if errors.Is(logErr, unix.ENOSPC) {
 		logStr += " (truncated...)"
 	}
 

--- a/internal/fd.go
+++ b/internal/fd.go
@@ -1,15 +1,15 @@
 package internal
 
 import (
+	"errors"
+	"fmt"
 	"runtime"
 	"strconv"
 
 	"github.com/DataDog/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
-var ErrClosedFd = xerrors.New("use of closed file descriptor")
+var ErrClosedFd = errors.New("use of closed file descriptor")
 
 type FD struct {
 	raw int64
@@ -56,7 +56,7 @@ func (fd *FD) Dup() (*FD, error) {
 
 	dup, err := unix.FcntlInt(uintptr(fd.raw), unix.F_DUPFD_CLOEXEC, 0)
 	if err != nil {
-		return nil, xerrors.Errorf("can't dup fd: %v", err)
+		return nil, fmt.Errorf("can't dup fd: %v", err)
 	}
 
 	return NewFD(uint32(dup)), nil

--- a/internal/feature.go
+++ b/internal/feature.go
@@ -1,14 +1,13 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"sync"
-
-	"golang.org/x/xerrors"
 )
 
 // ErrNotSupported indicates that a feature is not supported by the current kernel.
-var ErrNotSupported = xerrors.New("not supported")
+var ErrNotSupported = errors.New("not supported")
 
 // UnsupportedFeatureError is returned by FeatureTest() functions.
 type UnsupportedFeatureError struct {
@@ -69,7 +68,7 @@ func NewVersion(ver string) (Version, error) {
 	var major, minor, patch uint16
 	n, _ := fmt.Sscanf(ver, "%d.%d.%d", &major, &minor, &patch)
 	if n < 2 {
-		return Version{}, xerrors.Errorf("invalid version: %s", ver)
+		return Version{}, fmt.Errorf("invalid version: %s", ver)
 	}
 	return Version{major, minor, patch}, nil
 }

--- a/internal/feature_test.go
+++ b/internal/feature_test.go
@@ -1,10 +1,9 @@
 package internal
 
 import (
+	"errors"
 	"strings"
 	"testing"
-
-	"golang.org/x/xerrors"
 )
 
 func TestFeatureTest(t *testing.T) {
@@ -46,7 +45,7 @@ func TestFeatureTest(t *testing.T) {
 		t.Error("UnsupportedFeatureError.Error doesn't contain version")
 	}
 
-	if !xerrors.Is(err, ErrNotSupported) {
+	if !errors.Is(err, ErrNotSupported) {
 		t.Error("UnsupportedFeatureError is not ErrNotSupported")
 	}
 }

--- a/internal/io.go
+++ b/internal/io.go
@@ -1,6 +1,6 @@
 package internal
 
-import "golang.org/x/xerrors"
+import "errors"
 
 // DiscardZeroes makes sure that all written bytes are zero
 // before discarding them.
@@ -9,7 +9,7 @@ type DiscardZeroes struct{}
 func (DiscardZeroes) Write(p []byte) (int, error) {
 	for _, b := range p {
 		if b != 0 {
-			return 0, xerrors.New("encountered non-zero byte")
+			return 0, errors.New("encountered non-zero byte")
 		}
 	}
 	return len(p), nil

--- a/internal/testutils/feature.go
+++ b/internal/testutils/feature.go
@@ -2,12 +2,12 @@ package testutils
 
 import (
 	"bytes"
+	"errors"
 	"sync"
 	"testing"
 
 	"github.com/DataDog/ebpf/internal"
 	"github.com/DataDog/ebpf/internal/unix"
-	"golang.org/x/xerrors"
 )
 
 var (
@@ -49,7 +49,7 @@ func CheckFeatureTest(t *testing.T, fn func() error) {
 
 func SkipIfNotSupported(tb testing.TB, err error) {
 	var ufe *internal.UnsupportedFeatureError
-	if xerrors.As(err, &ufe) {
+	if errors.As(err, &ufe) {
 		checkKernelVersion(tb, ufe)
 		tb.Skip(ufe.Error())
 	}

--- a/linker.go
+++ b/linker.go
@@ -1,10 +1,10 @@
 package ebpf
 
 import (
+	"fmt"
+
 	"github.com/DataDog/ebpf/asm"
 	"github.com/DataDog/ebpf/internal/btf"
-
-	"golang.org/x/xerrors"
 )
 
 // link resolves bpf-to-bpf calls.
@@ -28,7 +28,7 @@ func link(prog *ProgramSpec, libs []*ProgramSpec) error {
 
 			needed, err := needSection(insns, lib.Instructions)
 			if err != nil {
-				return xerrors.Errorf("linking %s: %w", lib.Name, err)
+				return fmt.Errorf("linking %s: %w", lib.Name, err)
 			}
 
 			if !needed {
@@ -41,7 +41,7 @@ func link(prog *ProgramSpec, libs []*ProgramSpec) error {
 
 			if prog.BTF != nil && lib.BTF != nil {
 				if err := btf.ProgramAppend(prog.BTF, lib.BTF); err != nil {
-					return xerrors.Errorf("linking BTF of %s: %w", lib.Name, err)
+					return fmt.Errorf("linking BTF of %s: %w", lib.Name, err)
 				}
 			}
 		}

--- a/manager/editor_test.go
+++ b/manager/editor_test.go
@@ -48,7 +48,7 @@ func TestEditorRewriteConstant(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	progSpec := spec.Programs["rewrite"]
+	progSpec := spec.Programs["socket"]
 	editor := Edit(&progSpec.Instructions)
 
 	if err := editor.RewriteConstant("constant", 0x01); err != nil {

--- a/map.go
+++ b/map.go
@@ -1,21 +1,20 @@
 package ebpf
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/DataDog/ebpf/internal"
 	"github.com/DataDog/ebpf/internal/btf"
 	"github.com/DataDog/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
 // Errors returned by Map and MapIterator methods.
 var (
-	ErrKeyNotExist      = xerrors.New("key does not exist")
-	ErrKeyExist         = xerrors.New("key already exists")
-	ErrIterationAborted = xerrors.New("iteration aborted")
+	ErrKeyNotExist      = errors.New("key does not exist")
+	ErrKeyExist         = errors.New("key already exists")
+	ErrIterationAborted = errors.New("iteration aborted")
 )
 
 // MapID represents the unique ID of an eBPF map
@@ -92,7 +91,7 @@ type Map struct {
 // You should not use fd after calling this function.
 func NewMapFromFD(fd int) (*Map, error) {
 	if fd < 0 {
-		return nil, xerrors.New("invalid fd")
+		return nil, errors.New("invalid fd")
 	}
 	bpfFd := internal.NewFD(uint32(fd))
 
@@ -114,8 +113,8 @@ func NewMap(spec *MapSpec) (*Map, error) {
 	}
 
 	handle, err := btf.NewHandle(btf.MapSpec(spec.BTF))
-	if err != nil && !xerrors.Is(err, btf.ErrNotSupported) {
-		return nil, xerrors.Errorf("can't load BTF: %w", err)
+	if err != nil && !errors.Is(err, btf.ErrNotSupported) {
+		return nil, fmt.Errorf("can't load BTF: %w", err)
 	}
 
 	return newMapWithBTF(spec, handle)
@@ -127,7 +126,7 @@ func newMapWithBTF(spec *MapSpec, handle *btf.Handle) (*Map, error) {
 	}
 
 	if spec.InnerMap == nil {
-		return nil, xerrors.Errorf("%s requires InnerMap", spec.Type)
+		return nil, fmt.Errorf("%s requires InnerMap", spec.Type)
 	}
 
 	template, err := createMap(spec.InnerMap, nil, handle)
@@ -151,25 +150,25 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 		}
 
 		if abi.ValueSize != 0 && abi.ValueSize != 4 {
-			return nil, xerrors.New("ValueSize must be zero or four for map of map")
+			return nil, errors.New("ValueSize must be zero or four for map of map")
 		}
 		abi.ValueSize = 4
 
 	case PerfEventArray:
 		if abi.KeySize != 0 && abi.KeySize != 4 {
-			return nil, xerrors.New("KeySize must be zero or four for perf event array")
+			return nil, errors.New("KeySize must be zero or four for perf event array")
 		}
 		abi.KeySize = 4
 
 		if abi.ValueSize != 0 && abi.ValueSize != 4 {
-			return nil, xerrors.New("ValueSize must be zero or four for perf event array")
+			return nil, errors.New("ValueSize must be zero or four for perf event array")
 		}
 		abi.ValueSize = 4
 
 		if abi.MaxEntries == 0 {
 			n, err := internal.PossibleCPUs()
 			if err != nil {
-				return nil, xerrors.Errorf("perf event array: %w", err)
+				return nil, fmt.Errorf("perf event array: %w", err)
 			}
 			abi.MaxEntries = uint32(n)
 		}
@@ -177,7 +176,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 
 	if abi.Flags&(unix.BPF_F_RDONLY_PROG|unix.BPF_F_WRONLY_PROG) > 0 || spec.Freeze {
 		if err := haveMapMutabilityModifiers(); err != nil {
-			return nil, xerrors.Errorf("map create: %w", err)
+			return nil, fmt.Errorf("map create: %w", err)
 		}
 	}
 
@@ -193,7 +192,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 		var err error
 		attr.innerMapFd, err = inner.Value()
 		if err != nil {
-			return nil, xerrors.Errorf("map create: %w", err)
+			return nil, fmt.Errorf("map create: %w", err)
 		}
 	}
 
@@ -209,7 +208,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 
 	fd, err := bpfMapCreate(&attr)
 	if err != nil {
-		return nil, xerrors.Errorf("map create: %w", err)
+		return nil, fmt.Errorf("map create: %w", err)
 	}
 
 	m, err := newMap(fd, spec.Name, abi)
@@ -219,13 +218,13 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 
 	if err := m.populate(spec.Contents); err != nil {
 		m.Close()
-		return nil, xerrors.Errorf("map create: can't set initial contents: %w", err)
+		return nil, fmt.Errorf("map create: can't set initial contents: %w", err)
 	}
 
 	if spec.Freeze {
 		if err := m.Freeze(); err != nil {
 			m.Close()
-			return nil, xerrors.Errorf("can't freeze map: %w", err)
+			return nil, fmt.Errorf("can't freeze map: %w", err)
 		}
 	}
 
@@ -297,9 +296,9 @@ func (m *Map) Lookup(key, valueOut interface{}) error {
 		*value = m
 		return nil
 	case *Map:
-		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
+		return fmt.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
 	case Map:
-		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
+		return fmt.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
 
 	case **Program:
 		p, err := unmarshalProgram(valueBytes)
@@ -311,9 +310,9 @@ func (m *Map) Lookup(key, valueOut interface{}) error {
 		*value = p
 		return nil
 	case *Program:
-		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
+		return fmt.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
 	case Program:
-		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
+		return fmt.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
 
 	default:
 		return unmarshalBytes(valueOut, valueBytes)
@@ -328,11 +327,11 @@ func (m *Map) LookupAndDelete(key, valueOut interface{}) error {
 
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return xerrors.Errorf("can't marshal key: %w", err)
+		return fmt.Errorf("can't marshal key: %w", err)
 	}
 
 	if err := bpfMapLookupAndDelete(m.fd, keyPtr, valuePtr); err != nil {
-		return xerrors.Errorf("lookup and delete failed: %w", err)
+		return fmt.Errorf("lookup and delete failed: %w", err)
 	}
 
 	return unmarshalBytes(valueOut, valueBytes)
@@ -346,7 +345,7 @@ func (m *Map) LookupBytes(key interface{}) ([]byte, error) {
 	valuePtr := internal.NewSlicePointer(valueBytes)
 
 	err := m.lookup(key, valuePtr)
-	if xerrors.Is(err, ErrKeyNotExist) {
+	if errors.Is(err, ErrKeyNotExist) {
 		return nil, nil
 	}
 
@@ -356,11 +355,11 @@ func (m *Map) LookupBytes(key interface{}) ([]byte, error) {
 func (m *Map) lookup(key interface{}, valueOut internal.Pointer) error {
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return xerrors.Errorf("can't marshal key: %w", err)
+		return fmt.Errorf("can't marshal key: %w", err)
 	}
 
 	if err = bpfMapLookupElem(m.fd, keyPtr, valueOut); err != nil {
-		return xerrors.Errorf("lookup failed: %w", err)
+		return fmt.Errorf("lookup failed: %w", err)
 	}
 	return nil
 }
@@ -390,7 +389,7 @@ func (m *Map) Put(key, value interface{}) error {
 func (m *Map) Update(key, value interface{}, flags MapUpdateFlags) error {
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return xerrors.Errorf("can't marshal key: %w", err)
+		return fmt.Errorf("can't marshal key: %w", err)
 	}
 
 	var valuePtr internal.Pointer
@@ -400,11 +399,11 @@ func (m *Map) Update(key, value interface{}, flags MapUpdateFlags) error {
 		valuePtr, err = marshalPtr(value, int(m.abi.ValueSize))
 	}
 	if err != nil {
-		return xerrors.Errorf("can't marshal value: %w", err)
+		return fmt.Errorf("can't marshal value: %w", err)
 	}
 
 	if err = bpfMapUpdateElem(m.fd, keyPtr, valuePtr, uint64(flags)); err != nil {
-		return xerrors.Errorf("update failed: %w", err)
+		return fmt.Errorf("update failed: %w", err)
 	}
 
 	return nil
@@ -416,11 +415,11 @@ func (m *Map) Update(key, value interface{}, flags MapUpdateFlags) error {
 func (m *Map) Delete(key interface{}) error {
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return xerrors.Errorf("can't marshal key: %w", err)
+		return fmt.Errorf("can't marshal key: %w", err)
 	}
 
 	if err = bpfMapDeleteElem(m.fd, keyPtr); err != nil {
-		return xerrors.Errorf("delete failed: %w", err)
+		return fmt.Errorf("delete failed: %w", err)
 	}
 	return nil
 }
@@ -442,7 +441,7 @@ func (m *Map) NextKey(key, nextKeyOut interface{}) error {
 	}
 
 	if err := unmarshalBytes(nextKeyOut, nextKeyBytes); err != nil {
-		return xerrors.Errorf("can't unmarshal next key: %w", err)
+		return fmt.Errorf("can't unmarshal next key: %w", err)
 	}
 	return nil
 }
@@ -459,7 +458,7 @@ func (m *Map) NextKeyBytes(key interface{}) ([]byte, error) {
 	nextKeyPtr := internal.NewSlicePointer(nextKey)
 
 	err := m.nextKey(key, nextKeyPtr)
-	if xerrors.Is(err, ErrKeyNotExist) {
+	if errors.Is(err, ErrKeyNotExist) {
 		return nil, nil
 	}
 
@@ -475,12 +474,12 @@ func (m *Map) nextKey(key interface{}, nextKeyOut internal.Pointer) error {
 	if key != nil {
 		keyPtr, err = marshalPtr(key, int(m.abi.KeySize))
 		if err != nil {
-			return xerrors.Errorf("can't marshal key: %w", err)
+			return fmt.Errorf("can't marshal key: %w", err)
 		}
 	}
 
 	if err = bpfMapGetNextKey(m.fd, keyPtr, nextKeyOut); err != nil {
-		return xerrors.Errorf("next key failed: %w", err)
+		return fmt.Errorf("next key failed: %w", err)
 	}
 	return nil
 }
@@ -543,7 +542,7 @@ func (m *Map) Clone() (*Map, error) {
 
 	dup, err := m.fd.Dup()
 	if err != nil {
-		return nil, xerrors.Errorf("can't clone map: %w", err)
+		return nil, fmt.Errorf("can't clone map: %w", err)
 	}
 
 	return newMap(dup, m.name, &m.abi)
@@ -561,11 +560,11 @@ func (m *Map) Pin(fileName string) error {
 // It makes no changes to kernel-side restrictions.
 func (m *Map) Freeze() error {
 	if err := haveMapMutabilityModifiers(); err != nil {
-		return xerrors.Errorf("can't freeze map: %w", err)
+		return fmt.Errorf("can't freeze map: %w", err)
 	}
 
 	if err := bpfMapFreeze(m.fd); err != nil {
-		return xerrors.Errorf("can't freeze map: %w", err)
+		return fmt.Errorf("can't freeze map: %w", err)
 	}
 	return nil
 }
@@ -573,7 +572,7 @@ func (m *Map) Freeze() error {
 func (m *Map) populate(contents []MapKV) error {
 	for _, kv := range contents {
 		if err := m.Put(kv.Key, kv.Value); err != nil {
-			return xerrors.Errorf("key %v: %w", kv.Key, err)
+			return fmt.Errorf("key %v: %w", kv.Key, err)
 		}
 	}
 	return nil
@@ -607,7 +606,7 @@ func LoadPinnedMapExplicit(fileName string, abi *MapABI) (*Map, error) {
 
 func unmarshalMap(buf []byte) (*Map, error) {
 	if len(buf) != 4 {
-		return nil, xerrors.New("map id requires 4 byte value")
+		return nil, errors.New("map id requires 4 byte value")
 	}
 
 	// Looking up an entry in a nested map or prog array returns an id,
@@ -632,12 +631,12 @@ func patchValue(value []byte, typ btf.Type, replacements map[string]interface{})
 	replaced := make(map[string]bool)
 	replace := func(name string, offset, size int, replacement interface{}) error {
 		if offset+size > len(value) {
-			return xerrors.Errorf("%s: offset %d(+%d) is out of bounds", name, offset, size)
+			return fmt.Errorf("%s: offset %d(+%d) is out of bounds", name, offset, size)
 		}
 
 		buf, err := marshalBytes(replacement, size)
 		if err != nil {
-			return xerrors.Errorf("marshal %s: %w", name, err)
+			return fmt.Errorf("marshal %s: %w", name, err)
 		}
 
 		copy(value[offset:offset+size], buf)
@@ -661,7 +660,7 @@ func patchValue(value []byte, typ btf.Type, replacements map[string]interface{})
 		}
 
 	default:
-		return xerrors.Errorf("patching %T is not supported", typ)
+		return fmt.Errorf("patching %T is not supported", typ)
 	}
 
 	if len(replaced) == len(replacements) {
@@ -676,10 +675,10 @@ func patchValue(value []byte, typ btf.Type, replacements map[string]interface{})
 	}
 
 	if len(missing) == 1 {
-		return xerrors.Errorf("unknown field: %s", missing[0])
+		return fmt.Errorf("unknown field: %s", missing[0])
 	}
 
-	return xerrors.Errorf("unknown fields: %s", strings.Join(missing, ","))
+	return fmt.Errorf("unknown fields: %s", strings.Join(missing, ","))
 }
 
 // MapIterator iterates a Map.
@@ -699,7 +698,7 @@ func newMapIterator(target *Map, prevKey interface{}) *MapIterator {
 		target:     target,
 		maxEntries: target.abi.MaxEntries,
 		prevBytes:  make([]byte, int(target.abi.KeySize)),
-		prevKey: 	prevKey,
+		prevKey:    prevKey,
 	}
 }
 
@@ -738,7 +737,7 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 		mi.prevKey = mi.prevBytes
 
 		mi.err = mi.target.Lookup(nextBytes, valueOut)
-		if xerrors.Is(mi.err, ErrKeyNotExist) {
+		if errors.Is(mi.err, ErrKeyNotExist) {
 			// Even though the key should be valid, we couldn't look up
 			// its value. If we're iterating a hash map this is probably
 			// because a concurrent delete removed the value before we
@@ -757,7 +756,7 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 		return mi.err == nil
 	}
 
-	mi.err = xerrors.Errorf("%w", ErrIterationAborted)
+	mi.err = fmt.Errorf("%w", ErrIterationAborted)
 	return false
 }
 

--- a/map_test.go
+++ b/map_test.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -14,8 +15,6 @@ import (
 	"github.com/DataDog/ebpf/internal"
 	"github.com/DataDog/ebpf/internal/testutils"
 	"github.com/DataDog/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
 func TestMain(m *testing.M) {
@@ -75,11 +74,11 @@ func TestMapClose(t *testing.T) {
 		t.Fatal("Can't close map:", err)
 	}
 
-	if err := m.Put(uint32(0), uint32(42)); !xerrors.Is(err, internal.ErrClosedFd) {
+	if err := m.Put(uint32(0), uint32(42)); !errors.Is(err, internal.ErrClosedFd) {
 		t.Fatal("Put doesn't check for closed fd", err)
 	}
 
-	if _, err := m.LookupBytes(uint32(0)); !xerrors.Is(err, internal.ErrClosedFd) {
+	if _, err := m.LookupBytes(uint32(0)); !errors.Is(err, internal.ErrClosedFd) {
 		t.Fatal("Get doesn't check for closed fd", err)
 	}
 }
@@ -201,7 +200,7 @@ func TestMapQueue(t *testing.T) {
 		t.Error("Want value 4242, got", v)
 	}
 
-	if err := m.LookupAndDelete(nil, &v); !xerrors.Is(err, ErrKeyNotExist) {
+	if err := m.LookupAndDelete(nil, &v); !errors.Is(err, ErrKeyNotExist) {
 		t.Fatal("Lookup and delete on empty Queue:", err)
 	}
 }
@@ -435,7 +434,7 @@ func TestNotExist(t *testing.T) {
 
 	var tmp uint32
 	err := hash.Lookup("hello", &tmp)
-	if !xerrors.Is(err, ErrKeyNotExist) {
+	if !errors.Is(err, ErrKeyNotExist) {
 		t.Error("Lookup doesn't return ErrKeyNotExist")
 	}
 
@@ -447,11 +446,11 @@ func TestNotExist(t *testing.T) {
 		t.Error("LookupBytes returns non-nil buffer for non-existent key")
 	}
 
-	if err := hash.Delete("hello"); !xerrors.Is(err, ErrKeyNotExist) {
+	if err := hash.Delete("hello"); !errors.Is(err, ErrKeyNotExist) {
 		t.Error("Deleting unknown key doesn't return ErrKeyNotExist")
 	}
 
-	if err := hash.NextKey(nil, &tmp); !xerrors.Is(err, ErrKeyNotExist) {
+	if err := hash.NextKey(nil, &tmp); !errors.Is(err, ErrKeyNotExist) {
 		t.Error("Looking up next key in empty map doesn't return a non-existing error")
 	}
 }
@@ -464,7 +463,7 @@ func TestExist(t *testing.T) {
 		t.Errorf("Failed to put key/value pair into hash: %v", err)
 	}
 
-	if err := hash.Update("hello", uint32(42), UpdateNoExist); !xerrors.Is(err, ErrKeyExist) {
+	if err := hash.Update("hello", uint32(42), UpdateNoExist); !errors.Is(err, ErrKeyExist) {
 		t.Error("Updating existing key doesn't return ErrKeyExist")
 	}
 }
@@ -523,8 +522,8 @@ func TestPerCPUMarshaling(t *testing.T) {
 	defer arr.Close()
 
 	values := []*customEncoding{
-		&customEncoding{"hello"},
-		&customEncoding{"world"},
+		{"hello"},
+		{"world"},
 	}
 	if err := arr.Put(uint32(0), values); err != nil {
 		t.Fatal(err)
@@ -723,7 +722,7 @@ func TestMapGetNextID(t *testing.T) {
 	for {
 		last := next
 		if next, err = MapGetNextID(last); err != nil {
-			if !xerrors.Is(err, ErrNotExist) {
+			if !errors.Is(err, ErrNotExist) {
 				t.Fatal("Expected ErrNotExist, got:", err)
 			}
 			break
@@ -753,7 +752,7 @@ func TestNewMapFromID(t *testing.T) {
 
 	// As there can be multiple maps, we use max(uint32) as MapID to trigger an expected error.
 	_, err = NewMapFromID(MapID(math.MaxUint32))
-	if !xerrors.Is(err, ErrNotExist) {
+	if !errors.Is(err, ErrNotExist) {
 		t.Fatal("Expected ErrNotExist, got:", err)
 	}
 }
@@ -912,7 +911,7 @@ func BenchmarkMap(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			err := m.Delete(unsafe.Pointer(&key))
-			if err != nil && !xerrors.Is(err, ErrKeyNotExist) {
+			if err != nil && !errors.Is(err, ErrKeyNotExist) {
 				b.Fatal(err)
 			}
 		}

--- a/marshalers.go
+++ b/marshalers.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"reflect"
 	"runtime"
 	"unsafe"
 
 	"github.com/DataDog/ebpf/internal"
-
-	"golang.org/x/xerrors"
 )
 
 func marshalPtr(data interface{}, length int) (internal.Pointer, error) {
@@ -18,7 +18,7 @@ func marshalPtr(data interface{}, length int) (internal.Pointer, error) {
 		if length == 0 {
 			return internal.NewPointer(nil), nil
 		}
-		return internal.Pointer{}, xerrors.New("can't use nil as key of map")
+		return internal.Pointer{}, errors.New("can't use nil as key of map")
 	}
 
 	if ptr, ok := data.(unsafe.Pointer); ok {
@@ -42,12 +42,12 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 	case []byte:
 		buf = value
 	case unsafe.Pointer:
-		err = xerrors.New("can't marshal from unsafe.Pointer")
+		err = errors.New("can't marshal from unsafe.Pointer")
 	default:
 		var wr bytes.Buffer
 		err = binary.Write(&wr, internal.NativeEndian, value)
 		if err != nil {
-			err = xerrors.Errorf("encoding %T: %v", value, err)
+			err = fmt.Errorf("encoding %T: %v", value, err)
 		}
 		buf = wr.Bytes()
 	}
@@ -56,7 +56,7 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 	}
 
 	if len(buf) != length {
-		return nil, xerrors.Errorf("%T doesn't marshal to %d bytes", data, length)
+		return nil, fmt.Errorf("%T doesn't marshal to %d bytes", data, length)
 	}
 	return buf, nil
 }
@@ -92,13 +92,13 @@ func unmarshalBytes(data interface{}, buf []byte) error {
 		*value = buf
 		return nil
 	case string:
-		return xerrors.New("require pointer to string")
+		return errors.New("require pointer to string")
 	case []byte:
-		return xerrors.New("require pointer to []byte")
+		return errors.New("require pointer to []byte")
 	default:
 		rd := bytes.NewReader(buf)
 		if err := binary.Read(rd, internal.NativeEndian, value); err != nil {
-			return xerrors.Errorf("decoding %T: %v", value, err)
+			return fmt.Errorf("decoding %T: %v", value, err)
 		}
 		return nil
 	}
@@ -113,7 +113,7 @@ func unmarshalBytes(data interface{}, buf []byte) error {
 func marshalPerCPUValue(slice interface{}, elemLength int) (internal.Pointer, error) {
 	sliceType := reflect.TypeOf(slice)
 	if sliceType.Kind() != reflect.Slice {
-		return internal.Pointer{}, xerrors.New("per-CPU value requires slice")
+		return internal.Pointer{}, errors.New("per-CPU value requires slice")
 	}
 
 	possibleCPUs, err := internal.PossibleCPUs()
@@ -124,7 +124,7 @@ func marshalPerCPUValue(slice interface{}, elemLength int) (internal.Pointer, er
 	sliceValue := reflect.ValueOf(slice)
 	sliceLen := sliceValue.Len()
 	if sliceLen > possibleCPUs {
-		return internal.Pointer{}, xerrors.Errorf("per-CPU value exceeds number of CPUs")
+		return internal.Pointer{}, fmt.Errorf("per-CPU value exceeds number of CPUs")
 	}
 
 	alignedElemLength := align(elemLength, 8)
@@ -151,7 +151,7 @@ func marshalPerCPUValue(slice interface{}, elemLength int) (internal.Pointer, er
 func unmarshalPerCPUValue(slicePtr interface{}, elemLength int, buf []byte) error {
 	slicePtrType := reflect.TypeOf(slicePtr)
 	if slicePtrType.Kind() != reflect.Ptr || slicePtrType.Elem().Kind() != reflect.Slice {
-		return xerrors.Errorf("per-cpu value requires pointer to slice")
+		return fmt.Errorf("per-cpu value requires pointer to slice")
 	}
 
 	possibleCPUs, err := internal.PossibleCPUs()
@@ -170,7 +170,7 @@ func unmarshalPerCPUValue(slicePtr interface{}, elemLength int, buf []byte) erro
 
 	step := len(buf) / possibleCPUs
 	if step < elemLength {
-		return xerrors.Errorf("per-cpu element length is larger than available data")
+		return fmt.Errorf("per-cpu element length is larger than available data")
 	}
 	for i := 0; i < possibleCPUs; i++ {
 		var elem interface{}
@@ -188,7 +188,7 @@ func unmarshalPerCPUValue(slicePtr interface{}, elemLength int, buf []byte) erro
 
 		err := unmarshalBytes(elem, elemBytes)
 		if err != nil {
-			return xerrors.Errorf("cpu %d: %w", i, err)
+			return fmt.Errorf("cpu %d: %w", i, err)
 		}
 
 		buf = buf[step:]

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -2,6 +2,7 @@ package perf
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -11,13 +12,11 @@ import (
 	"github.com/DataDog/ebpf"
 	"github.com/DataDog/ebpf/internal"
 	"github.com/DataDog/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
 var (
-	errClosed = xerrors.New("perf reader was closed")
-	errEOR    = xerrors.New("end of ring")
+	errClosed = errors.New("perf reader was closed")
+	errEOR    = errors.New("end of ring")
 )
 
 // perfEventHeader must match 'struct perf_event_header` in <linux/perf_event.h>.
@@ -29,7 +28,7 @@ type perfEventHeader struct {
 
 func addToEpoll(epollfd, fd int, cpu int) error {
 	if int64(cpu) > math.MaxInt32 {
-		return xerrors.Errorf("unsupported CPU number: %d", cpu)
+		return fmt.Errorf("unsupported CPU number: %d", cpu)
 	}
 
 	// The representation of EpollEvent isn't entirely accurate.
@@ -43,7 +42,7 @@ func addToEpoll(epollfd, fd int, cpu int) error {
 	}
 
 	if err := unix.EpollCtl(epollfd, unix.EPOLL_CTL_ADD, fd, &event); err != nil {
-		return xerrors.Errorf("can't add fd to epoll: %v", err)
+		return fmt.Errorf("can't add fd to epoll: %v", err)
 	}
 	return nil
 }
@@ -88,7 +87,7 @@ func readRecord(rd io.Reader, cpu int) (Record, error) {
 	}
 
 	if err != nil {
-		return Record{}, xerrors.Errorf("can't read event header: %v", err)
+		return Record{}, fmt.Errorf("can't read event header: %v", err)
 	}
 
 	switch header.Type {
@@ -114,7 +113,7 @@ func readLostRecords(rd io.Reader) (uint64, error) {
 
 	err := binary.Read(rd, internal.NativeEndian, &lostHeader)
 	if err != nil {
-		return 0, xerrors.Errorf("can't read lost records header: %v", err)
+		return 0, fmt.Errorf("can't read lost records header: %v", err)
 	}
 
 	return lostHeader.Lost, nil
@@ -124,12 +123,12 @@ func readRawSample(rd io.Reader) ([]byte, error) {
 	// This must match 'struct perf_event_sample in kernel sources.
 	var size uint32
 	if err := binary.Read(rd, internal.NativeEndian, &size); err != nil {
-		return nil, xerrors.Errorf("can't read sample size: %v", err)
+		return nil, fmt.Errorf("can't read sample size: %v", err)
 	}
 
 	data := make([]byte, int(size))
 	if _, err := io.ReadFull(rd, data); err != nil {
-		return nil, xerrors.Errorf("can't read sample: %v", err)
+		return nil, fmt.Errorf("can't read sample: %v", err)
 	}
 	return data, nil
 }
@@ -183,12 +182,12 @@ func NewReader(array *ebpf.Map, perCPUBuffer int) (*Reader, error) {
 // NewReaderWithOptions creates a new reader with the given options.
 func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions) (pr *Reader, err error) {
 	if perCPUBuffer < 1 {
-		return nil, xerrors.New("perCPUBuffer must be larger than 0")
+		return nil, errors.New("perCPUBuffer must be larger than 0")
 	}
 
 	epollFd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
 	if err != nil {
-		return nil, xerrors.Errorf("can't create epoll fd: %v", err)
+		return nil, fmt.Errorf("can't create epoll fd: %v", err)
 	}
 
 	var (
@@ -216,7 +215,7 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 	// Hence we have to create a ring for each CPU.
 	for i := 0; i < nCPU; i++ {
 		ring, err := newPerfEventRing(i, perCPUBuffer, opts.Watermark)
-		if xerrors.Is(err, unix.ENODEV) {
+		if errors.Is(err, unix.ENODEV) {
 			// The requested CPU is currently offline, skip it.
 			rings = append(rings, nil)
 			pauseFds = append(pauseFds, -1)
@@ -224,7 +223,7 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 		}
 
 		if err != nil {
-			return nil, xerrors.Errorf("failed to create perf ring for CPU %d: %v", i, err)
+			return nil, fmt.Errorf("failed to create perf ring for CPU %d: %v", i, err)
 		}
 		rings = append(rings, ring)
 		pauseFds = append(pauseFds, ring.fd)
@@ -282,7 +281,7 @@ func (pr *Reader) Close() error {
 		internal.NativeEndian.PutUint64(value[:], 1)
 		_, err = unix.Write(pr.closeFd, value[:])
 		if err != nil {
-			err = xerrors.Errorf("can't write event fd: %v", err)
+			err = fmt.Errorf("can't write event fd: %v", err)
 			return
 		}
 
@@ -309,7 +308,7 @@ func (pr *Reader) Close() error {
 		pr.array.Close()
 	})
 	if err != nil {
-		return xerrors.Errorf("close PerfReader: %w", err)
+		return fmt.Errorf("close PerfReader: %w", err)
 	}
 	return nil
 }
@@ -387,8 +386,8 @@ func (pr *Reader) Pause() error {
 	}
 
 	for i := range pr.pauseFds {
-		if err := pr.array.Delete(uint32(i)); err != nil && !xerrors.Is(err, ebpf.ErrKeyNotExist) {
-			return xerrors.Errorf("could't delete event fd for CPU %d: %w", i, err)
+		if err := pr.array.Delete(uint32(i)); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+			return fmt.Errorf("could't delete event fd for CPU %d: %w", i, err)
 		}
 	}
 
@@ -412,7 +411,7 @@ func (pr *Reader) Resume() error {
 		}
 
 		if err := pr.array.Put(uint32(i), uint32(fd)); err != nil {
-			return xerrors.Errorf("couldn't put event fd %d for CPU %d: %w", fd, i, err)
+			return fmt.Errorf("couldn't put event fd %d for CPU %d: %w", fd, i, err)
 		}
 	}
 
@@ -426,7 +425,7 @@ type temporaryError interface {
 // IsClosed returns true if the error occurred because
 // a Reader was closed.
 func IsClosed(err error) bool {
-	return xerrors.Is(err, errClosed)
+	return errors.Is(err, errClosed)
 }
 
 type unknownEventError struct {
@@ -441,5 +440,5 @@ func (uev *unknownEventError) Error() string {
 // because an unknown event was submitted to the perf event ring.
 func IsUnknownEvent(err error) bool {
 	var uee *unknownEventError
-	return xerrors.As(err, &uee)
+	return errors.As(err, &uee)
 }

--- a/perf/ring.go
+++ b/perf/ring.go
@@ -1,6 +1,8 @@
 package perf
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -9,8 +11,6 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
 // perfEventRing is a page of metadata followed by
@@ -24,7 +24,7 @@ type perfEventRing struct {
 
 func newPerfEventRing(cpu, perCPUBuffer, watermark int) (*perfEventRing, error) {
 	if watermark >= perCPUBuffer {
-		return nil, xerrors.New("watermark must be smaller than perCPUBuffer")
+		return nil, errors.New("watermark must be smaller than perCPUBuffer")
 	}
 
 	fd, err := createPerfEvent(cpu, watermark)
@@ -40,7 +40,7 @@ func newPerfEventRing(cpu, perCPUBuffer, watermark int) (*perfEventRing, error) 
 	mmap, err := unix.Mmap(fd, 0, perfBufferSize(perCPUBuffer), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
 	if err != nil {
 		unix.Close(fd)
-		return nil, xerrors.Errorf("can't mmap: %v", err)
+		return nil, fmt.Errorf("can't mmap: %v", err)
 	}
 
 	// This relies on the fact that we allocate an extra metadata page,
@@ -101,7 +101,7 @@ func createPerfEvent(cpu, watermark int) (int, error) {
 	attr.Size = uint32(unsafe.Sizeof(attr))
 	fd, err := unix.PerfEventOpen(&attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
 	if err != nil {
-		return -1, xerrors.Errorf("can't create perf event: %w", err)
+		return -1, fmt.Errorf("can't create perf event: %w", err)
 	}
 	return fd, nil
 }

--- a/prog_test.go
+++ b/prog_test.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -18,7 +19,6 @@ import (
 	"github.com/DataDog/ebpf/internal"
 	"github.com/DataDog/ebpf/internal/testutils"
 	"github.com/DataDog/ebpf/internal/unix"
-	"golang.org/x/xerrors"
 )
 
 func TestProgramRun(t *testing.T) {
@@ -271,7 +271,7 @@ func TestProgramVerifierOutput(t *testing.T) {
 	}
 
 	var ve *internal.VerifierError
-	if !xerrors.As(err, &ve) {
+	if !errors.As(err, &ve) {
 		t.Error("Error is not a VerifierError")
 	}
 }
@@ -459,7 +459,7 @@ func TestProgramGetNextID(t *testing.T) {
 	for {
 		last := next
 		if next, err = ProgramGetNextID(last); err != nil {
-			if !xerrors.Is(err, ErrNotExist) {
+			if !errors.Is(err, ErrNotExist) {
 				t.Fatal("Expected ErrNotExist, got:", err)
 			}
 			break
@@ -498,7 +498,7 @@ func TestNewProgramFromID(t *testing.T) {
 
 	// As there can be multiple programs, we use max(uint32) as ProgramID to trigger an expected error.
 	_, err = NewProgramFromID(ProgramID(math.MaxUint32))
-	if !xerrors.Is(err, ErrNotExist) {
+	if !errors.Is(err, ErrNotExist) {
 		t.Fatal("Expected ErrNotExist, got:", err)
 	}
 }

--- a/syscalls.go
+++ b/syscalls.go
@@ -1,19 +1,19 @@
 package ebpf
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
 	"unsafe"
 
 	"github.com/DataDog/ebpf/internal"
 	"github.com/DataDog/ebpf/internal/btf"
 	"github.com/DataDog/ebpf/internal/unix"
-
-	"golang.org/x/xerrors"
 )
 
 // Generic errors returned by BPF syscalls.
 var (
-	ErrNotExist = xerrors.New("requested object does not exit")
+	ErrNotExist = errors.New("requested object does not exit")
 )
 
 // bpfObjName is a null-terminated string made up of
@@ -324,11 +324,11 @@ func wrapObjError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if xerrors.Is(err, unix.ENOENT) {
-		return xerrors.Errorf("%w", ErrNotExist)
+	if errors.Is(err, unix.ENOENT) {
+		return fmt.Errorf("%w", ErrNotExist)
 	}
 
-	return xerrors.New(err.Error())
+	return errors.New(err.Error())
 }
 
 func wrapMapError(err error) error {
@@ -336,15 +336,15 @@ func wrapMapError(err error) error {
 		return nil
 	}
 
-	if xerrors.Is(err, unix.ENOENT) {
+	if errors.Is(err, unix.ENOENT) {
 		return ErrKeyNotExist
 	}
 
-	if xerrors.Is(err, unix.EEXIST) {
+	if errors.Is(err, unix.EEXIST) {
 		return ErrKeyExist
 	}
 
-	return xerrors.New(err.Error())
+	return errors.New(err.Error())
 }
 
 func bpfMapFreeze(m *internal.FD) error {
@@ -369,7 +369,7 @@ func bpfPinObject(fileName string, fd *internal.FD) error {
 		return err
 	}
 	if uint64(statfs.Type) != bpfFSType {
-		return xerrors.Errorf("%s is not on a bpf filesystem", fileName)
+		return fmt.Errorf("%s is not on a bpf filesystem", fileName)
 	}
 
 	value, err := fd.Value()
@@ -382,7 +382,7 @@ func bpfPinObject(fileName string, fd *internal.FD) error {
 		fd:       value,
 	}), 16)
 	if err != nil {
-		return xerrors.Errorf("pin object %s: %w", fileName, err)
+		return fmt.Errorf("pin object %s: %w", fileName, err)
 	}
 	return nil
 }
@@ -392,7 +392,7 @@ func bpfGetObject(fileName string) (*internal.FD, error) {
 		fileName: internal.NewStringPointer(fileName),
 	}), 16)
 	if err != nil {
-		return nil, xerrors.Errorf("get object %s: %w", fileName, err)
+		return nil, fmt.Errorf("get object %s: %w", fileName, err)
 	}
 	return internal.NewFD(uint32(ptr)), nil
 }
@@ -411,7 +411,7 @@ func bpfGetObjectInfoByFD(fd *internal.FD, info unsafe.Pointer, size uintptr) er
 	}
 	_, err = internal.BPF(_ObjGetInfoByFD, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
 	if err != nil {
-		return xerrors.Errorf("fd %d: %w", fd, err)
+		return fmt.Errorf("fd %d: %w", fd, err)
 	}
 	return nil
 }
@@ -419,7 +419,7 @@ func bpfGetObjectInfoByFD(fd *internal.FD, info unsafe.Pointer, size uintptr) er
 func bpfGetProgInfoByFD(fd *internal.FD) (*bpfProgInfo, error) {
 	var info bpfProgInfo
 	if err := bpfGetObjectInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info)); err != nil {
-		return nil, xerrors.Errorf("can't get program info: %w", err)
+		return nil, fmt.Errorf("can't get program info: %w", err)
 	}
 	return &info, nil
 }
@@ -428,7 +428,7 @@ func bpfGetMapInfoByFD(fd *internal.FD) (*bpfMapInfo, error) {
 	var info bpfMapInfo
 	err := bpfGetObjectInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info))
 	if err != nil {
-		return nil, xerrors.Errorf("can't get map info: %w", err)
+		return nil, fmt.Errorf("can't get map info: %w", err)
 	}
 	return &info, nil
 }


### PR DESCRIPTION
The stdlib equivalents have been available since Go 1.13.

While profiling some ebpf code with a hotpath using `Map.Lookup`, I noticed that the `xerrors.Errorf` function was generating a stack trace on every call. Since this happens anytime a key doesn't exist in the map, this can be a significant performance penalty.