### PR TITLE
Do not use fmt.Errorf on Lookup hot path

### DIFF
--- a/map.go
+++ b/map.go
@@ -359,7 +359,7 @@ func (m *Map) lookup(key interface{}, valueOut internal.Pointer) error {
 	}
 
 	if err = bpfMapLookupElem(m.fd, keyPtr, valueOut); err != nil {
-		return fmt.Errorf("lookup failed: %w", err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
It can contribute to ~33% more time spent