### PR TITLE
Implement perf_event_open ABI to attach kprobes and uprobes

### DIFF
--- a/manager/syscalls.go
+++ b/manager/syscalls.go
@@ -11,29 +11,86 @@ import (
 	"github.com/DataDog/ebpf/internal"
 )
 
-func perfEventOpenTracepoint(id int, progFd int) (*internal.FD, error) {
+// perfEventOpenWithProbe - Kernel API with e12f03d ("perf/core: Implement the 'perf_kprobe' PMU") allows
+// creating [k,u]probe with perf_event_open, which makes it easier to clean up
+// the [k,u]probe. This function tries to create pfd with the perf_kprobe PMU.
+func perfEventOpenWithProbe(name string, offset, pid int, sectionPrefix string, referenceCounterOffset uint64) (int, error) {
+	var err error
+	attr := unix.PerfEventAttr{
+		Sample: 1,
+		Wakeup: 1,
+		Ext2: uint64(offset), // config2 here is kprobe_addr or probe_offset
+	}
+	attr.Size = uint32(unsafe.Sizeof(attr))
+
+	attr.Type, err = FindPMUType(sectionPrefix)
+	if err != nil {
+		return 0, errors.Wrapf(err, "couldn't find PMU type for %s", sectionPrefix)
+	}
+
+	var returnBit uint32
+	returnBit, err = FindRetProbeBit(sectionPrefix)
+	if err != nil {
+		return 0, errors.Wrapf(err, "couldn't find retprobe bit for %s", sectionPrefix)
+	}
+	if returnBit > 0 {
+		attr.Config = 1 << returnBit
+	}
+	if referenceCounterOffset > 0 {
+		attr.Config |= referenceCounterOffset << 32
+	}
+
+	namePtr, err := syscall.BytePtrFromString(name)
+	if err != nil {
+		return 0, errors.Wrapf(err, "couldn't create pointer to string %s", name)
+	}
+	// config1 here is kprobe_func or uprobe_path
+	attr.Ext1 = uint64(uintptr(unsafe.Pointer(namePtr)))
+
+	// PID filter is only possible for uprobe events.
+	if pid < 0 {
+		pid = -1
+	}
+	// perf_event_open API doesn't allow both pid and cpu to be -1.
+	// So only set it to -1 when PID is not -1.
+	// Tracing events do not do CPU filtering in any cases.
+	var cpu int
+	if pid != -1 {
+		cpu = -1
+	}
+
+	efd, err := unix.PerfEventOpen(&attr, pid, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	if efd < 0 {
+		return 0, errors.Wrap(err, "perf_event_open error")
+	}
+	return efd, nil
+}
+
+func perfEventOpenTracingEvent(probeID int) (int, error) {
 	attr := unix.PerfEventAttr{
 		Type:        unix.PERF_TYPE_TRACEPOINT,
 		Sample_type: unix.PERF_SAMPLE_RAW,
 		Sample:      1,
 		Wakeup:      1,
-		Config:      uint64(id),
+		Config:      uint64(probeID),
 	}
 	attr.Size = uint32(unsafe.Sizeof(attr))
 
 	efd, err := unix.PerfEventOpen(&attr, -1, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
 	if efd < 0 {
-		return nil, errors.Wrap(err, "perf_event_open error")
+		return 0, errors.Wrap(err, "perf_event_open error")
 	}
+	return efd, nil
+}
 
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(efd), unix.PERF_EVENT_IOC_ENABLE, 0); err != 0 {
-		return nil, errors.Wrap(err, "error enabling perf event")
+func ioctlPerfEventEnable(perfEventOpenFD int, progFD int) error {
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD), unix.PERF_EVENT_IOC_SET_BPF, uintptr(progFD)); err != 0 {
+		return errors.Wrap(err, "error attaching bpf program to perf event")
 	}
-
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(efd), unix.PERF_EVENT_IOC_SET_BPF, uintptr(progFd)); err != 0 {
-		return nil, errors.Wrap(err, "error attaching bpf program to perf event")
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, uintptr(perfEventOpenFD), unix.PERF_EVENT_IOC_ENABLE, 0); err != 0 {
+		return errors.Wrap(err, "error enabling perf event")
 	}
-	return internal.NewFD(uint32(efd)), nil
+	return nil
 }
 
 type bpfProgAttachAttr struct {


### PR DESCRIPTION
What does this PR do ?
-----------------------

This PR introduces the perf_event_open ABI to attach kprobes and uprobes ([e12f03d](https://github.com/torvalds/linux/commit/e12f03d7031a977356e3d7b75a68c2185ff8d155) "perf/core: Implement the 'perf_kprobe' PMU"). With this PR, the manager will no longer use `kprobe_events` and `uprobe_events` to attach kprobes and uprobes. This has multiple benefits that are explained in the Kernel patch notes.

The manager will start by using this ABI, and if it fails, will fall back to the usual `kprobe_events` / `uprobe_events` implementation.