### PR TITLE
Handle overflow of kernel version parts in parsing

### DIFF
--- a/kernel_version.go
+++ b/kernel_version.go
@@ -35,20 +35,21 @@ func KernelVersionFromReleaseString(releaseString string) (uint32, error) {
 	if len(versionParts) < 3 {
 		return 0, fmt.Errorf("got invalid release version %q (expected format '4.3.2-1')", releaseString)
 	}
-	major, err := strconv.Atoi(versionParts[1])
+	var major, minor, patch uint64
+	var err error
+	major, err = strconv.ParseUint(versionParts[1], 10, 8)
 	if err != nil {
 		return 0, err
 	}
 
-	minor, err := strconv.Atoi(versionParts[2])
+	minor, err = strconv.ParseUint(versionParts[2], 10, 8)
 	if err != nil {
 		return 0, err
 	}
 
 	// patch is optional
-	patch := 0
 	if len(versionParts) >= 4 {
-		patch, _ = strconv.Atoi(versionParts[3])
+		patch, _ = strconv.ParseUint(versionParts[3], 10, 8)
 	}
 	out := major*256*256 + minor*256 + patch
 	return uint32(out), nil

--- a/kernel_version_test.go
+++ b/kernel_version_test.go
@@ -70,6 +70,8 @@ func TestParseDebianVersion(t *testing.T) {
 		{true, "Linux version 3.16.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 4.9.2 (Debian 4.9.2-10+deb8u2) ) #1 SMP Debian 3.16.68-1 (2019-05-22)", 200772},
 		// Invalid
 		{false, "Linux version 4.9.125-linuxkit (root@659b6d51c354) (gcc version 6.4.0 (Alpine 6.4.0) ) #1 SMP Fri Sep 7 08:20:28 UTC 2018", 0},
+		// 4.9.258-1 overflow of patch version which has max 255
+		{true, "Linux version 4.9.0-15-amd64 (debian-kernel@lists.debian.org) (gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) ) #1 SMP Debian 4.9.258-1 (2021-03-08)", 264703},
 	} {
 		version, err := parseDebianVersion(tc.releaseString)
 		if err != nil && tc.succeed {


### PR DESCRIPTION
The patch/subversion can be above 255, but the kernel only expects a max of 255 (uint8). 