### PR TITLE
Prevent dirty entries in kprobe_events because of maxactive misshandling

### DIFF
--- a/manager/probe.go
+++ b/manager/probe.go
@@ -561,8 +561,10 @@ func (p *Probe) attachKprobe() error {
 
 	// Write kprobe_events line to register kprobe
 	kprobeID, err := EnableKprobeEvent(probeType, funcName, p.UID, maxactiveStr, p.attachPID)
-	// fallback without KProbeMaxActive
 	if err == ErrKprobeIDNotExist {
+		// The probe might have been loaded under a kernel generated event name. Clean up just in case.
+		_ = disableKprobeEvent(getKernelGeneratedEventName(probeType, funcName))
+		// fallback without KProbeMaxActive
 		kprobeID, err = EnableKprobeEvent(probeType, funcName, p.UID, "", p.attachPID)
 	}
 	if err != nil {

--- a/manager/utils.go
+++ b/manager/utils.go
@@ -187,6 +187,12 @@ func GenerateEventName(probeType, funcName, UID string, attachPID int) (string, 
 	return eventName, nil
 }
 
+// getKernelGeneratedEventName returns the pattern used by the kernel when a [k|u]probe is loaded without an event name.
+// The library doesn't support loading a [k|u]probe with an address directly, so only one pattern applies here.
+func getKernelGeneratedEventName(probeType, funcName string) string {
+	return fmt.Sprintf("%s_%s_0", probeType, funcName)
+}
+
 // ReadKprobeEvents - Returns the content of kprobe_events
 func ReadKprobeEvents() (string, error) {
 	kprobeEvents, err := ioutil.ReadFile("/sys/kernel/debug/tracing/kprobe_events")


### PR DESCRIPTION
Some context
--------------

The `maxactive` parameter in `kprobe_events` was introduced in kernel 4.12. Before 4.12, the kernel would simply parse the program type and ignore any other characters past `p`, `r` or `-` if it is not `:` (which would signal the beginning of the user defined event name). As the kernel can't detect the event name when you provide a maxactive, it [would generate a custom one](https://elixir.bootlin.com/linux/v4.11.12/source/kernel/trace/trace_kprobe.c#L707) using one of the following patterns: `[probe_type]_[funcname]_[offset_from_symbol]` or `[probe_type]_[address]`. Since the library doesn't support loading kprobes directly with an address, we only care about the first one.

What happened ?
-----------------

In its current state, the library tries to register the kprobe with a `maxactive` first, and then falls back without it, if it couldn't find the kprobe id file (identified by the event name). However, kernels < 4.12 might have successfully loaded the kprobe with a new event name, as explained in the first section. This new entry will never be used or deleted because the manager doesn't know about it.

What does this PR do ?
-----------------------

This PR introduces a cleanup of the kernel generated event pattern in case the kprobe id file couldn't be found.

Other options
--------------

We could have checked that the kernel version is above `4.12`, but this wouldn't handle Centos kernels that have the required back ports to support `maxactive`.