### PR TITLE
Paulcacheux/cleanup instructions

### DIFF
--- a/manager/examples/programs/kprobe/main.go
+++ b/manager/examples/programs/kprobe/main.go
@@ -48,6 +48,11 @@ func main() {
 		logrus.Fatal(err)
 	}
 
+	// Cleanup the manager
+	if err := m.UnloadProbesInstructions(); err != nil {
+		logrus.Fatal(err)
+	}
+
 	logrus.Println("successfully started")
 	logrus.Println("=> head over to /sys/kernel/debug/tracing/trace_pipe")
 	logrus.Println("=> checkout /sys/kernel/debug/tracing/kprobe_events, utimes_common might have become utimes_common.isra.0")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -577,6 +577,21 @@ func (m *Manager) Start() error {
 	return nil
 }
 
+func (m *Manager) UnloadProbesInstructions() error {
+	m.stateLock.Lock()
+	defer m.stateLock.Unlock()
+	if m.state < initialized {
+		return ErrManagerNotInitialized
+	}
+
+	for _, probe := range m.Probes {
+		probe.programSpec.Instructions = nil
+	}
+
+	// m.collectionSpec = nil
+	return nil
+}
+
 // Stop - Detach all eBPF programs and stop perf ring readers. The cleanup parameter defines which maps should be closed.
 // See MapCleanupType for mode.
 func (m *Manager) Stop(cleanup MapCleanupType) error {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -577,6 +577,7 @@ func (m *Manager) Start() error {
 	return nil
 }
 
+// UnloadProbesInstructions - Unload instructions for each probe, should save memory
 func (m *Manager) UnloadProbesInstructions() error {
 	m.stateLock.Lock()
 	defer m.stateLock.Unlock()
@@ -585,10 +586,9 @@ func (m *Manager) UnloadProbesInstructions() error {
 	}
 
 	for _, probe := range m.Probes {
-		probe.programSpec.Instructions = nil
+		probe.UnloadInstructions()
 	}
 
-	// m.collectionSpec = nil
 	return nil
 }
 

--- a/manager/probe.go
+++ b/manager/probe.go
@@ -850,3 +850,8 @@ func (p *Probe) detachXDP() error {
 	err = netlink.LinkSetXdpFdWithFlags(link, -1, int(p.XDPAttachMode))
 	return errors.Wrapf(err, "couldn't detach XDP program %v from interface %v", p.GetIdentificationPair(), p.Ifindex)
 }
+
+// UnloadInstructions - Unload instructions for each probe, should save memory
+func (p *Probe) UnloadInstructions() {
+	p.programSpec.Instructions = nil
+}


### PR DESCRIPTION
# What does this PR do ?

This PRs allows the manager to unload asm instructions from probes, in order to save memory. Of course this renders a lot of operation on the probes (like attachment) impossible but this can be useful if the manager is done setting up the probe.